### PR TITLE
Fix blueprint default for numeric values

### DIFF
--- a/app/lib/pagedata.php
+++ b/app/lib/pagedata.php
@@ -8,7 +8,7 @@ class PageData {
 
     if(empty($default)) {
       return '';
-    } else if(is_string($default)) {
+    } else if(is_string($default) || is_numeric($default)) {
       return $default;
     } else {
       $type = a::get($default, 'type');


### PR DESCRIPTION
This PR fixes an error when numeric default values did not work.

```
postalcode:
  label: PLZ
  type:  text
  default: 1234
```

-> did not work

```
place:
  label: Ort
  type:  text
  default: Footown
```

-> worked
