### PR TITLE
Index option of autocomplete accepts uri

### DIFF
--- a/app/controllers/api/helpers.php
+++ b/app/controllers/api/helpers.php
@@ -45,6 +45,8 @@ class HelpersController extends Controller {
           case 'all':
             $pages = site()->index();
             break;
+          default:
+            $pages = site()->page($index)->children();
         }
         $result = $pages->pluck(get('field', 'tags'), get('separator', true), true);
         break;


### PR DESCRIPTION
This would allow the following blueprint:

```
title: Recipes
fields:
    title:
        label: Title
        type: text
/// interesting bit starts here
    ingredients:
        label: Ingredient(s)
        type: tags
        index: ingredients
        field: uid
```

Where that would autocomplete with any children of the page `/ingredients`
