### PR TITLE
Fixing another bug when date format is not ISO 8601

### DIFF
--- a/app/fields/date/assets/js/date.min.js
+++ b/app/fields/date/assets/js/date.min.js
@@ -15,7 +15,7 @@
       input.on('change', function() {
         var val = input.val();
         if(val) {
-          hidden.val(moment(val).format('YYYY-MM-DD'));
+          hidden.val(moment(val, format).format('YYYY-MM-DD'));
         } else {
           hidden.val('');
         }


### PR DESCRIPTION
Passing the format of the date field to moment.js solves the validation error when date format of the field is not like YYYY-MM-DD.
