### PR TITLE
Fixing camel cased field names

### DIFF
--- a/app/lib/form.php
+++ b/app/lib/form.php
@@ -44,7 +44,7 @@ class Form extends Brick {
 
       if($name == 'title') $field['type'] = 'title';
 
-      $name = str_replace('-','_', str::lower($name));
+      $name = str_replace('-','_', $name);
 
       $field['name']    = $name;
       $field['default'] = a::get($field, 'default', null);


### PR DESCRIPTION
See #280.
Error introduced in 2.0.3 (Ticket #275)
