### PR TITLE
Allow overriding the blueprint field 'title' required parameter.

### DIFF
--- a/app/lib/blueprint/field.php
+++ b/app/lib/blueprint/field.php
@@ -19,7 +19,10 @@ class Field extends Obj {
 
     if(a::get($params, 'name') == 'title') {
       $params['type']     = 'title';
-      $params['required'] = true;
+
+      if (!isset($params['required'])) {
+        $params['required'] = true;
+      }
     }
 
     if(empty($params['type'])) {


### PR DESCRIPTION
I noticed the panel sets the required parameter to true if a field name is set to 'title'. This works fine and is expected for most cases but, in my set up for instance, I have files that have a "title" field and a longer "caption" field.

I don't require a title to be filled out on all my images so this change means we can override the required status for the "title" by setting `required: false` in the blueprint. The other option might be to not require a title field for files specifically.
