### PR TITLE
Allow overriding time field on each page edit.

### DIFF
--- a/app/fields/time/time.php
+++ b/app/fields/time/time.php
@@ -1,7 +1,8 @@
 <?php
 
 class TimeField extends SelectField {
-
+  public $override = false;
+  
   public function __construct() {
     $this->icon     = 'clock-o';
     $this->interval = 60;
@@ -10,7 +11,11 @@ class TimeField extends SelectField {
 
   public function value() {
 
-    $value = parent::value();
+	if ($this->override()) {
+      $value = $this->default();
+	} else {
+      $value = parent::value();
+    }
 
     if(empty($value)) {
       $time  = round(time() / ($this->interval * 60)) * ($this->interval * 60);


### PR DESCRIPTION
A simple addition that allows an `override: true` field option on the time field to force the field to update to the current time on each page edit. Useful for `updated` time fields.
