### PR TITLE
Allow overriding date field on each page edit.

### DIFF
--- a/app/fields/date/date.php
+++ b/app/fields/date/date.php
@@ -1,6 +1,7 @@
 <?php
 
 class DateField extends InputField {
+  public $override = false;
 
   static public $assets = array(
     'js' => array(
@@ -31,6 +32,10 @@ class DateField extends InputField {
   }
 
   public function value() {
+    if ($this->override()) {
+      $this->value = $this->default();
+    }
+
     return !empty($this->value) ? date('Y-m-d', strtotime($this->value)) : null;
   }
 


### PR DESCRIPTION
A simple addition that allows an `override: true` field option on the date field to force the field to update to the current date on each page edit. Useful for `updated` date fields.
