### PR TITLE
field variable sets autocompletion index

### DIFF
--- a/app/fields/tags/tags.php
+++ b/app/fields/tags/tags.php
@@ -13,7 +13,6 @@ class TagsField extends TextField {
     $this->icon      = 'tag';
     $this->label     = l::get('fields.tags.label', 'Tags');
     $this->index     = 'siblings';
-    $this->field     = 'tags';
     $this->separator = ',';
     $this->lower     = false;
 
@@ -35,10 +34,12 @@ class TagsField extends TextField {
 
     } else if($page = $this->page()) {
 
+      empty($this->field) ? $field = $this->name() : $field = $this->field;
+
       $query = array(
         'uri'       => $page->id(),
         'index'     => $this->index(),
-        'field'     => $this->name(),
+        'field'     => $field,
         'separator' => $this->separator()
       );
 


### PR DESCRIPTION
the variable $this->field was set but not used right?
I made this change so that the field variable defines the field indexed for the autocompletion.
usage example where the uri's of all pages are used for autocompletion:

```
related:
    label: Related pages
    type: tags
    index: all
    lower: true
    field: uri
```
