### PR TITLE
Add encodeURIComponent

### DIFF
--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -621,7 +621,7 @@ $.fn.shortcuts = function() {
 
 };
 $.toSlug = function(string, callback) {
-  $http.get('slug/?string=' + string, callback);
+  $http.get('slug/?string=' + encodeURIComponent(string), callback);
 };
 $.fn.breadcrumb = function() {
 


### PR DESCRIPTION
String to create the slug is not encoded, causing the slug generation in panel to break as soon as there is an ampersand.
