### PR TITLE
Enable chaining for sort in blueprints.

### DIFF
--- a/app/lib/api.php
+++ b/app/lib/api.php
@@ -62,12 +62,8 @@ class Api {
         $pages = $pages->flip();
         break;
       default;
-
         $parts = str::split($blueprint->pages()->sort(), ' ');
-        if(count($parts) > 2) {
-          $pages = call_user_func_array(array($pages, 'sortBy'), $parts);
-        }
-
+        $pages = call_user_func_array(array($pages, 'sortBy'), $parts);
         break;
     }
 

--- a/app/lib/api.php
+++ b/app/lib/api.php
@@ -64,11 +64,8 @@ class Api {
       default;
 
         $parts = str::split($blueprint->pages()->sort(), ' ');
-        $field = a::get($parts, 0);
-        $order = a::get($parts, 1);
-
-        if($field) {
-          $pages = $pages->sortBy($field, $order);
+        if(count($parts) > 2) {
+          $pages = call_user_func_array(array($pages, 'sortBy'), $parts);
         }
 
         break;

--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -621,7 +621,7 @@ $.fn.shortcuts = function() {
 
 };
 $.toSlug = function(string, callback) {
-  $http.get('slug/?string=' + string, callback);
+  $http.get('slug/?string=' + encodeURIComponent(string), callback);
 };
 $.fn.breadcrumb = function() {
 


### PR DESCRIPTION
Enable chaining for sort in blueprints so that you can use multiple fields to sort on. For instance in case a date and a time field are being used you could get those sorted correctly in the panel by using: `sort: date desc time desc` in your blueprint file.