### PR TITLE
Don't fire keyboard shortcuts on contenteditable elements

### DIFF
--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -79,6 +79,7 @@ this.Handlebars=function(){var a=function(){"use strict";function a(a){this.stri
     handleObj.handler = function( event ) {
       // Don't fire in text-accepting inputs that we didn't directly bind to
       if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
+        ($(event.target).prop('contenteditable') == 'true' ) ||
         ( jQuery.hotkeys.options.filterTextInputs &&
           jQuery.inArray(event.target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1 ) ) ) {
         return;


### PR DESCRIPTION
As mentioned in #347 there is an issue with the keyboard shortcuts being fired while the focus lies on a `contenteditable` element.

This additional check should fix this.