### PR TITLE
Enabled sorting on multiple fields

### DIFF
--- a/app/lib/api.php
+++ b/app/lib/api.php
@@ -64,11 +64,9 @@ class Api {
       default;
 
         $parts = str::split($blueprint->pages()->sort(), ' ');
-        $field = a::get($parts, 0);
-        $order = a::get($parts, 1);
 
-        if($field) {
-          $pages = $pages->sortBy($field, $order);
+        if (count($parts) > 0) {
+          $pages = call_user_func_array(array($pages, 'sortBy'), $parts);
         }
 
         break;


### PR DESCRIPTION
Enable sorting on multiple fields so you could use `sort: date desc time desc` in a blueprint. This is already possible on the frontend of Kirby by using:

```PHP
$page->children()->visible()->sortBy('date', 'desc', 'time', 'desc');
```