### PR TITLE
Optional widgets

### DIFF
--- a/app/views/dashboard/index.php
+++ b/app/views/dashboard/index.php
@@ -92,17 +92,19 @@
     </div>
 
     <?php foreach($widgets as $widget): ?>
-    <div class="section white dashboard-section">
+      <?php if ($widget): ?>
+        <div class="section white dashboard-section">
 
-      <h2 class="hgroup hgroup-single-line cf">
-        <span class="hgroup-title">
-          <?php __($widget['title']) ?>
-        </span>
-      </h2>
+          <h2 class="hgroup hgroup-single-line cf">
+            <span class="hgroup-title">
+              <?php __($widget['title']) ?>
+            </span>
+          </h2>
 
-      <?php echo $widget['html']() ?>
+          <?php echo $widget['html']() ?>
 
-    </div>
+        </div>
+      <?php endif; ?>
     <?php endforeach ?>
 
     <div class="section white dashboard-section">


### PR DESCRIPTION
A widget can decide based on any factor that I should not be displayed in the
panel (e.g. a version-widget can hide itself from any user who is not an admin
as the presented information would not be very useful).

Instead of returning and `array('title', 'html')` the widget code returns false.
In this case the dashboard does not create a new widget box.