### PR TITLE
Files blueprint option: type

### DIFF
--- a/app/controllers/api/files.php
+++ b/app/controllers/api/files.php
@@ -25,7 +25,7 @@ class FilesController extends Controller {
 
     if($file = $upload->file()) {
       try {
-        $this->checkUpload($file);
+        $this->checkUpload($file, $blueprint);
         return response::success('success');
       } catch(Exception $e) {
         $file->delete();
@@ -188,7 +188,7 @@ class FilesController extends Controller {
     }
   }
 
-  protected function checkUpload($file) {
+  protected function checkUpload($file, $blueprint) {
 
     if(strtolower($file->extension()) == kirby()->option('content.file.extension', 'txt')) {
       throw new Exception('Content files cannot be uploaded');
@@ -202,8 +202,10 @@ class FilesController extends Controller {
       throw new Exception('htaccess files cannot be uploaded');
     } else if(str::startsWith($file->filename(), '.')) {
       throw new Exception('Invisible files cannot be uploaded');
+    } else if($blueprint->files()->type() !== null and $blueprint->files()->type() != $file->type()) {
+      throw new Exception('Only '.$blueprint->files()->type().'s allowed');
     }
-    
+
   }
 
 }

--- a/app/controllers/api/files.php
+++ b/app/controllers/api/files.php
@@ -202,8 +202,8 @@ class FilesController extends Controller {
       throw new Exception('htaccess files cannot be uploaded');
     } else if(str::startsWith($file->filename(), '.')) {
       throw new Exception('Invisible files cannot be uploaded');
-    } else if($blueprint->files()->type() !== null and $blueprint->files()->type() != $file->type()) {
-      throw new Exception('Only '.$blueprint->files()->type().'s allowed');
+    } else if(count($blueprint->files()->type()) > 0 and !in_array($file->type(), $blueprint->files()->type())) {
+      throw new Exception('File format not allowed for this page.');
     }
 
   }

--- a/app/lib/blueprint/files.php
+++ b/app/lib/blueprint/files.php
@@ -13,6 +13,7 @@ class Files extends Obj {
   public $sort     = null;
   public $sortable = false;
   public $sanitize = true;
+  public $type     = null;
 
   public function __construct($params = array()) {
 
@@ -23,6 +24,7 @@ class Files extends Obj {
       $this->max      = 0;
       $this->sortable = false;
       $this->hide     = true;
+      $this->type     = null;
       $this->fields   = array();
     } else if(is_array($params)) {
       $this->max      = a::get($params, 'max', $this->max);
@@ -31,6 +33,7 @@ class Files extends Obj {
       $this->sortable = a::get($params, 'sortable', $this->sortable);
       $this->fields   = a::get($params, 'fields', array());
       $this->sanitize = a::get($params, 'sanitize', true);
+      $this->type      = a::get($params, 'type', $this->type);
     }
 
   }

--- a/app/lib/blueprint/files.php
+++ b/app/lib/blueprint/files.php
@@ -13,7 +13,7 @@ class Files extends Obj {
   public $sort     = null;
   public $sortable = false;
   public $sanitize = true;
-  public $type     = null;
+  public $type     = array();
 
   public function __construct($params = array()) {
 
@@ -24,7 +24,7 @@ class Files extends Obj {
       $this->max      = 0;
       $this->sortable = false;
       $this->hide     = true;
-      $this->type     = null;
+      $this->type     = array();
       $this->fields   = array();
     } else if(is_array($params)) {
       $this->max      = a::get($params, 'max', $this->max);
@@ -33,7 +33,13 @@ class Files extends Obj {
       $this->sortable = a::get($params, 'sortable', $this->sortable);
       $this->fields   = a::get($params, 'fields', array());
       $this->sanitize = a::get($params, 'sanitize', true);
-      $this->type      = a::get($params, 'type', $this->type);
+
+      $this->type     = a::get($params, 'type', array());
+      if (!is_array($this->type)) {
+        $this->type   = array($this->type);
+      }
+
+
     }
 
   }


### PR DESCRIPTION
Adds a type option to the files blueprint which can be set to one or multiple file types - other file types will not be accepted for that blueprint.

Not user if this is wanted for the panel in this form or at all, but I though I'd just offer it in the form of a pull request.