### PR TITLE
image render size in file list variable

### DIFF
--- a/app/views/files/index.php
+++ b/app/views/files/index.php
@@ -29,7 +29,7 @@
    --><div class="grid-item" id="<?php __($file->filename()) ?>">
         <figure class="file">
           <a class="file-preview file-preview-is-{{type}}" href="<?php echo purl($file, 'show') ?>">
-            <?php if(in_array($file->extension(), array('jpg', 'gif', 'png')) and $file->width() < 2000 and $file->height() < 2000): ?>
+            <?php if(in_array($file->extension(), array('jpg', 'gif', 'png')) and $file->width() < c::get('panel.max_image_render_width', '2000') and $file->height() < c::get('panel.max_image_render_height', '2000')): ?>
             <?php echo thumb($file, array('width' => 300, 'height' => '200', 'crop' => true)) ?>
             <?php else: ?>
             <span><?php __($file->extension()) ?></span>


### PR DESCRIPTION
Most hi-res stock photo's and images directly from camera's are larger than the 2000 px max resolution that was set for rendering the image in the thumbnail. By making this variable there's a choice to go for some additional load, but happy end users because they can see their images in the thumbnails. :-)