### PR TITLE
Adjust file options position after RTL

### DIFF
--- a/assets/scss/components/_file.scss
+++ b/assets/scss/components/_file.scss
@@ -72,13 +72,6 @@
 @media screen and (min-width: 120em) {
   .file-options .btn {
     padding: 1em 1.5em;
-
-    body.ltr & {
-      text-align: left;
-    }
-    body.rtl & {
-      text-align: right;
-    }
   }
   .file-options .btn span {
     display: inline;


### PR DESCRIPTION
I am not too sure about this one, cause I cannot grasp why there was a `text-align: left` before the RTL changes anyways. Shouldn't it just inherit the `text-align: center`?

Also: It takes really big screens to reach that `120em` width :laughing: 