### PR TITLE
Add possibility for blueprint snippets

### DIFF
--- a/app/lib/blueprint/fields.php
+++ b/app/lib/blueprint/fields.php
@@ -11,12 +11,16 @@ class Fields extends Collection {
     if(empty($fields) or !is_array($fields)) $fields = array();
 
     foreach($fields as $name => $field) {
-      if($field['type'] == 'import'){
-        // Import a blueprint snippet
-        foreach(\blueprint::find('snippets' . DS . $field['snippet'])->fields($page) AS $f){
-          $this->append($f->name, $f);
-        }
-        continue;
+      if($field['type'] == 'snippet'){
+          // Import blueprint snippets
+          $snippets = is_array($field['file']) ? $field['file'] : array($field['file']);
+          foreach($snippets AS $snippet){
+              foreach(\blueprint::find('snippets' . DS . $snippet)->fields($page) AS $file){
+                  $this->append($file->name, $file);
+              }
+          }
+          // Handle next field
+          continue;
       }
       
       // add the name to the field

--- a/app/lib/blueprint/fields.php
+++ b/app/lib/blueprint/fields.php
@@ -11,7 +11,14 @@ class Fields extends Collection {
     if(empty($fields) or !is_array($fields)) $fields = array();
 
     foreach($fields as $name => $field) {
-
+      if($field['type'] == 'import'){
+        // Import a blueprint snippet
+        foreach(\blueprint::find('snippets' . DS . $field['snippet'])->fields($page) AS $f){
+          $this->append($f->name, $f);
+        }
+        continue;
+      }
+      
       // add the name to the field
       $field['name'] = $name;
       $field['page'] = $page;


### PR DESCRIPTION
Imagine the following scenario:

You extracted a complex part of template code (e.g. a visual slider) to a template snippet like 'slider.php'. This snippet is ment to be used by many different templates.

But in order to configure the slider in the panel you have to add and maintain ALL fields for the slider in EVERY page blueprint that uses the slider in frontend.

```
# blueprints/home.php
fields:
  title:
    label: Titel
    type:  text
  text:
    label: Text
    type:  textarea
    size:  large
  lbl_sliders:
    label: Slider
    type: headline
  sliders:
    label: Elemente
    type: structure
    entry: >
      {{headline}}
    fields: [...]
```

My modification enables you to import a "Blueprint Field Snippet" into any other snippet.

Create a new folder site/blueprints/snippets and place a new blueprint inside:

```
# blueprints/snippets/slider.php
fields:
  lbl_sliders:
    label: Slider
    type: headline
  sliders:
    label: Elemente
    type: structure
    entry: >
      {{headline}}
    fields: [...]
```

Afterwards you can import the fields defined in this snippet into ANY other blueprint like this:

```
# blueprints/home.php
fields: 
  title:
    label: Titel
    type:  text
  text:
    label: Text
    type:  textarea
    size:  large
  im_slider:
    type: snippet
    file: slider
```

You can also import multiple snippets at once by specifying the 'file' attribute as array:

```
fields:
  imports: 
    type: snippet
    file: 
      - file1
      - file2
```