### PR TITLE
Selectfield: no blank option if required & default

### DIFF
--- a/app/fields/select/select.php
+++ b/app/fields/select/select.php
@@ -35,7 +35,8 @@ class SelectField extends BaseField {
       'disabled'     => $this->disabled(),
     ));
 
-    if (!$this->required() or empty($this->default())) {
+    $default = $this->default();
+    if (!$this->required() or empty($default)) {
       $select->append($this->option('', '', $this->value() == ''));
     }
 

--- a/app/fields/select/select.php
+++ b/app/fields/select/select.php
@@ -35,7 +35,9 @@ class SelectField extends BaseField {
       'disabled'     => $this->disabled(),
     ));
 
-    $select->append($this->option('', '', $this->value() == ''));
+    if (!$this->required() or empty($this->default())) {
+      $select->append($this->option('', '', $this->value() == ''));
+    }
 
     if($this->readonly()) {
       $select->attr('tabindex', '-1');


### PR DESCRIPTION
The select field does not include a blank option at top if required is set true and a default value is set.