### PR TITLE
Time field - default now included, fix #449

### DIFF
--- a/app/fields/time/time.php
+++ b/app/fields/time/time.php
@@ -1,9 +1,9 @@
 <?php
 
 class TimeField extends SelectField {
-  
+
   public $override = false;
-  
+
   public function __construct() {
     $this->icon     = 'clock-o';
     $this->interval = 60;
@@ -18,10 +18,12 @@ class TimeField extends SelectField {
       $value = parent::value();
     }
 
-    if(empty($value)) {
-      $time  = round(time() / ($this->interval * 60)) * ($this->interval * 60);
-      $value = date($this->format(), $time);
+    if(empty($value) or $value == 'now') {
+      $value = date($this->format(), time());
     }
+
+    $time  = round((strtotime($value) - strtotime('00:00')) / ($this->interval * 60)) * ($this->interval * 60) + strtotime('00:00');
+    $value = date($this->format(), $time);
 
     return $value;
 


### PR DESCRIPTION
Includes a 'default: now' option for the time field and also fixes the calculation of the nearest time intervall to (pre-)select the correct select option. Thus, the default option **can** be set to a time that does not match the specified intervall, but the panel will still select the nearest available time intervall option now.