### PR TITLE
Number field: visual feedback if out of range

### DIFF
--- a/app/fields/number/assets/css/number.css
+++ b/app/fields/number/assets/css/number.css
@@ -1,0 +1,3 @@
+.input:out-of-range:focus {
+  border-color: #b3000a;
+}

--- a/app/fields/number/number.php
+++ b/app/fields/number/number.php
@@ -2,6 +2,12 @@
 
 class NumberField extends InputField {
 
+  static public $assets = array(
+    'css' => array(
+      'number.css'
+    )
+  );
+
   public function __construct() {
 
     $this->type        = 'number';


### PR DESCRIPTION
An idea, does not necessarily need to be included in this way. Just thought that it might be interesting to use `:out-of-range`. However, browser support in IE and Firefox is limited :/

I'll just leave this as pull request as an idea.