### PR TITLE
Field Option Query and Relative Paths

### DIFF
--- a/app/lib/fieldoptions.php
+++ b/app/lib/fieldoptions.php
@@ -58,6 +58,10 @@ class FieldOptions {
           $path = str::substr($path, 3);
         }
         $page = $currentPage;
+
+        if ($path && $currentPage->find($path)) {
+          $page = $currentPage->find($path);
+        }
       } else {
         $page = page($query['page']);        
       }


### PR DESCRIPTION
I've found it useful to reference pages that aren't just a direct `parent` of the current page.

For example, I might want to grab a known child of one of the ancestors of a given page:
```yaml
fields:
  presenter:
    label: Presenter
    type: select
    options: query
    query:
      page: ../../../presenters
      fetch: children
```

We can be assured that this page exists, because a strict chain of Blueprints enforces a template structure down to the current page.

This small change tests for child pages after fetching the most distant parent requested, based on the remainder of the passed path.

Bastian, if there are tests that correspond to this feature, I'm happy to read up and add them, as well!