### PR TITLE
add more fieldoptions: show the visible or invisible root folders in …

### DIFF
--- a/app/lib/fieldoptions.php
+++ b/app/lib/fieldoptions.php
@@ -150,6 +150,14 @@ class FieldOptions {
         $items = $page->index();
         $items = $items->sortBy('title', 'asc');
         break;
+      case 'visibleRoot':
+        $items = site()->children()->visible();
+        $items = $items->sortBy('title', 'asc');
+        break;
+      case 'invisibleRoot':
+        $items = site()->children()->invisible();
+        $items = $items->sortBy('title', 'asc');
+        break;
       case 'children':
       case 'files':
       case 'images':


### PR DESCRIPTION
An easy way to show all visible or invisible root folders in a blueprint query select.