### PR TITLE
Fixes tags autocomplete in structure fields, #327

### DIFF
--- a/app/controllers/api/helpers.php
+++ b/app/controllers/api/helpers.php
@@ -54,21 +54,19 @@ class HelpersController extends Controller {
             }
         }
 
-        $field  = get('field', 'tags');
-        $yaml   = get('yaml', false);
+        $field      = get('field', 'tags');
+        $yaml       = get('yaml', false);
+        $separator  = get('separator', true);
 
         if($yaml) {
           $result = array();
           foreach($pages as $page) {
-            $row = $pages->extractValue($page, $yaml);
-            $row = yaml::decode($row);
-            if(isset($row[0][$field])) {
-              $result = array_merge($result, str::split($row[0][$field], get('separator', true)));
-            }
+            $values = $page->$yaml()->toStructure()->pluck($field, $separator, true);
+            $result = array_merge($result, $values);
           }
           $result = array_unique($result);
         } else {
-          $result = $pages->pluck($field, get('separator', true), true);
+          $result = $pages->pluck($field, $separator, true);
         }
         break;
       default:

--- a/app/controllers/api/helpers.php
+++ b/app/controllers/api/helpers.php
@@ -53,7 +53,23 @@ class HelpersController extends Controller {
               return response::json(array());
             }
         }
-        $result = $pages->pluck(get('field', 'tags'), get('separator', true), true);
+
+        $field  = get('field', 'tags');
+        $yaml   = get('yaml', false);
+
+        if($yaml) {
+          $result = array();
+          foreach($pages as $page) {
+            $row = $pages->extractValue($page, $yaml);
+            $row = yaml::decode($row);
+            if(isset($row[0][$field])) {
+              $result = array_merge($result, str::split($row[0][$field], get('separator', true)));
+            }
+          }
+          $result = array_unique($result);
+        } else {
+          $result = $pages->pluck($field, get('separator', true), true);
+        }
         break;
       default:
         return response::error('Invalid autocomplete method');

--- a/app/controllers/views/editor.php
+++ b/app/controllers/views/editor.php
@@ -66,8 +66,8 @@ class EditorController extends Controller {
       if($field['type'] == 'textarea') $fields[$key]['buttons'] = false;
     }
 
-    $form       = new Form($fields);
-    $form->save = get('_id') ? l('fields.structure.save') : l('fields.structure.add');
+    $form        = new Form($fields, null, $fieldName);
+    $form->save  = get('_id') ? l('fields.structure.save') : l('fields.structure.add');
 
     return view('editor/structure', array(
       'page' => $page,

--- a/app/fields/base/base.php
+++ b/app/fields/base/base.php
@@ -24,6 +24,7 @@ class BaseField {
   public $width;
   public $default;
   public $error = false;
+  public $parentField = false;
 
   public function root() {
     $obj = new ReflectionClass($this);

--- a/app/fields/tags/tags.php
+++ b/app/fields/tags/tags.php
@@ -40,7 +40,8 @@ class TagsField extends TextField {
         'uri'       => $page->id(),
         'index'     => $this->index(),
         'field'     => $field,
-        'separator' => $this->separator()
+        'yaml'      => $this->parentField,
+        'separator' => $this->separator(),
       );
 
       $input->data('url', panel()->urls()->api() . '/autocomplete/field?' . http_build_query($query));

--- a/app/lib/form.php
+++ b/app/lib/form.php
@@ -5,18 +5,22 @@ class Form extends Brick {
   static public $root  = array();
   static public $files = null;
 
-  public $tag      = 'form';
-  public $fields   = array();
-  public $values   = array();
-  public $alert    = null;
-  public $save     = true;
-  public $cancel   = true;
-  public $centered = false;
-  public $back     = false;
+  public $tag         = 'form';
+  public $fields      = array();
+  public $values      = array();
+  public $alert       = null;
+  public $save        = true;
+  public $cancel      = true;
+  public $centered    = false;
+  public $back        = false;
+  public $parentField = false;
 
-  public function __construct($fields = array(), $values = array()) {
+  public function __construct($fields = array(), $values = array(), $parent = false) {
 
     $this->fields = new Collection;
+
+    // if Form is part of a structureField, set structureField name
+    $this->parentField = $parent;
 
     $this->values($values);
     $this->fields($fields);
@@ -49,6 +53,9 @@ class Form extends Brick {
       $field['name']    = $name;
       $field['default'] = a::get($field, 'default', null);
       $field['value']   = a::get($this->values(), $name, $field['default']);
+
+      // Pass through parent field name (structureField)
+      $field['parentField'] = $this->parentField;
 
       $this->fields->append($name, static::field($field['type'], $field));
 


### PR DESCRIPTION
This commit fixes the autocomplete for tags fields within structure field forms.

Frankly, this does not seem to be the nicest solution. It might be better to find a more radical solution to better deal with yaml fields - so that `pluck()` could actually also work with structure subfields.

Especially the loop added to `app/controllers/api/helpers.php` might rather belong somewhere in the Collection class or so.

But as I got this solution working for now, I thought I'd just share it as a pull request, which does not necessary need to be merged, but maybe helps as a starting point for a discussion on this rather fundamental issue with structure (sub-)fields.