### PR TITLE
Prevents add pages with numeric title, fix #326

### DIFF
--- a/app/controllers/api/pages.php
+++ b/app/controllers/api/pages.php
@@ -4,9 +4,14 @@ class PagesController extends Controller {
 
   public function create($id = '') {
 
-    try {
+    $title = get('title');
 
-      $page = api::createPage($id, get('title'), get('template'), get('uid'));
+    if(v::num(str::substr($title, 0, 1))) {
+      return response::error(l('pages.error.title.num'));
+    }
+
+    try {
+      $page = api::createPage($id, $title, get('template'), get('uid'));
 
       kirby()->trigger('panel.page.create', $page);
 

--- a/app/languages/de.php
+++ b/app/languages/de.php
@@ -128,6 +128,7 @@ return array(
     'pages.search.help' => 'Durchsuche alle Seiten nach URL-Pfad. Du kannst dich durch Ergebnisse mit den Pfeiltasten bewegen und per Enter zur ausgewählten Seite springen.',
     'pages.search.noresults' => 'Es gibt leider keine Seiten zu deiner Suche. Bitte versuche es mit einem anderen Pfad.',
     'pages.error.missing' => 'Die Seite konnte nicht gefunden werden',
+    'pages.error.title.num' => 'Titel darf nicht mit einer Nummer beginnen.',
 
     // subpages
     'subpages' => 'Seiten',

--- a/app/languages/en.php
+++ b/app/languages/en.php
@@ -129,6 +129,7 @@ return array(
     'pages.search.help' => 'Search pages by URL. Navigate through search results with your up and down arrow keys and hit enter to jump to the selected page.',
     'pages.search.noresults' => 'There are no search results for your query. Please try again with a different URL.',
     'pages.error.missing' => 'The page could not be found',
+    'pages.error.title.num' => 'Title must not begin with a numeric character.',
 
     // subpages
     'subpages' => 'Pages',


### PR DESCRIPTION
Since page titles starting with a number will cause odd behavior when created (number will not be interpreted as part of the slug title, but as the sort number of a visible page), this pull request would simply restrict a page title to not start with a numeric character at creation:

![screen shot 2015-05-18 at 20 53 47](https://cloud.githubusercontent.com/assets/3788865/7687849/657441ec-fda0-11e4-8534-a793a59f52e3.png)
