### PR TITLE
Prevents add pages with number-led UID, fix #326

### DIFF
--- a/app/controllers/api/pages.php
+++ b/app/controllers/api/pages.php
@@ -4,9 +4,13 @@ class PagesController extends Controller {
 
   public function create($id = '') {
 
-    try {
+    $uid = get('uid');
+    if(v::num(str::substr($uid, 0, 1))) {
+      return response::error(l('pages.error.uid.num'));
+    }
 
-      $page = api::createPage($id, get('title'), get('template'), get('uid'));
+    try {
+      $page = api::createPage($id, get('title'), get('template'), $uid);
 
       kirby()->trigger('panel.page.create', $page);
 
@@ -98,13 +102,13 @@ class PagesController extends Controller {
 
           if($num > 0) {
             $page->sort($num);
-          } 
+          }
 
         }
 
       }
 
-      // get the blueprint of the parent page to find the 
+      // get the blueprint of the parent page to find the
       // correct sorting mode for this page
       $parentBlueprint = blueprint::find($page->parent());
 

--- a/app/languages/de.php
+++ b/app/languages/de.php
@@ -128,6 +128,7 @@ return array(
     'pages.search.help' => 'Durchsuche alle Seiten nach URL-Pfad. Du kannst dich durch Ergebnisse mit den Pfeiltasten bewegen und per Enter zur ausgewählten Seite springen.',
     'pages.search.noresults' => 'Es gibt leider keine Seiten zu deiner Suche. Bitte versuche es mit einem anderen Pfad.',
     'pages.error.missing' => 'Die Seite konnte nicht gefunden werden',
+    'pages.error.uid.num' => 'URL-Anhang darf nicht mit einer Nummer beginnen',
 
     // subpages
     'subpages' => 'Seiten',

--- a/app/languages/en.php
+++ b/app/languages/en.php
@@ -129,6 +129,7 @@ return array(
     'pages.search.help' => 'Search pages by URL. Navigate through search results with your up and down arrow keys and hit enter to jump to the selected page.',
     'pages.search.noresults' => 'There are no search results for your query. Please try again with a different URL.',
     'pages.error.missing' => 'The page could not be found',
+    'pages.error.uid.num' => 'URL-appendix must not begin with a number',
 
     // subpages
     'subpages' => 'Pages',


### PR DESCRIPTION
Since page url slugs starting with a number will cause odd behavior when created (number will not be interpreted as part of the slug title, but as the sort number of a visible page), this pull request would simply restrict a page url appendix / slug to not start with a numeric character at creation.