### PR TITLE
Add css pointer on structure Add link

### DIFF
--- a/app/fields/structure/assets/css/structure.css
+++ b/app/fields/structure/assets/css/structure.css
@@ -18,7 +18,7 @@
   border-bottom: 1px solid #efefef;
 }
 .structure[data-sortable=true] .structure-entry-content {
-  cursor: move;  
+  cursor: move;
 }
 .structure-entry-options .btn {
   padding: .75em 1.5em;
@@ -36,4 +36,7 @@
 }
 .structure-empty a:hover {
   border-color: #000;
+}
+.structure-add-button {
+  cursor: pointer;
 }


### PR DESCRIPTION
The "Add" link currently lacks a cursor: pointer; declaration, so the arrow remains when the cursor is over it.
Links usually get this pointer from the user agent stylesheet, but here it is overridden by the surrounding ```label```.

![pointer](https://cloud.githubusercontent.com/assets/193492/7801761/2e147a70-032a-11e5-8dd8-afe99af6b21b.png)
