### PR TITLE
allow multi-language content for headline field

### DIFF
--- a/app/fields/headline/headline.php
+++ b/app/fields/headline/headline.php
@@ -17,7 +17,7 @@ class HeadlineField extends BaseField {
   }
 
   public function content() {
-    return '<h2 class="hgroup hgroup-single-line hgroup-compressed cf"><span class="hgroup-title">' . html($this->label) . '</span></h2>';
+    return '<h2 class="hgroup hgroup-single-line hgroup-compressed cf"><span class="hgroup-title">' . html($this->i18n($this->label)) . '</span></h2>';
   }
 
   public function element() {


### PR DESCRIPTION
Small change that allows the use of multiple languages for the label of a headline field in a blueprint.

Example: 

```
content:
  label:
    en: Content
    fr: Contenu
  type: headline
```
