### PR TITLE
Inputfield better empty default values, fix #497

### DIFF
--- a/app/lib/blueprint/field.php
+++ b/app/lib/blueprint/field.php
@@ -42,7 +42,7 @@ class Field extends Obj {
       return 'true';
     } else if($default === false) {
       return 'false';
-    } else if(empty($default)) {
+    } else if(empty($default) and strlen($default) == 0) {
       return '';
     } else if(is_string($default)) {
       return $default;


### PR DESCRIPTION
Using only empty() here also removes strings, integers and floats of 0. Additionally testing with strlen() seems to be one solution to not test all of the other cases:

```php
and $default !== '0' and $default !== 0 and...
```