### PR TITLE
Fix bug in detecting localhosts when verifying license

### DIFF
--- a/app/panel.php
+++ b/app/panel.php
@@ -305,7 +305,7 @@ class Panel {
 
     return new Obj(array(
       'key'   => $key,
-      'local' => in_array(server::get('SERVER_ADDR'), $localhosts),
+      'local' => (in_array(server::get('SERVER_ADDR'), $localhosts) or server::get('SERVER_NAME') == 'localhost'),
       'type'  => $type,
     ));
 


### PR DESCRIPTION
Noticed a bug where a new local install of Kirby claimed to be running as unlicensed on a public server because my url was "http://localhost:8000/panel/#/".

This fix checks for 'SERVER_NAME' in addition to 'SERVER_ADDR'.