### PR TITLE
Enables custom page icon set in blueprint, fix #97

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -72,7 +72,12 @@ function i($icon, $position = null) {
   if(is_string($icon)) {
     echo '<i class="icon' . r($position, ' icon-' . $position) . ' fa fa-' . $icon . '"></i>';
   } else if(is_a($icon, 'Page')) {
-    i('file-o', 'left');
+    $blueprint = blueprint::find($icon);
+    if($i = $blueprint->icon()) {
+      i($i, 'left');
+    } else {
+      i('file-o', 'left');
+    }
   } else if(is_a($icon, 'File')) {
 
     switch($icon->type()) {
@@ -133,7 +138,7 @@ function purl($obj, $action = false) {
   } else if(is_a($obj, 'File')) {
     if($obj->page()->isSite()) {
       return '#/files/' . $action . '/' . urlencode($obj->filename());
-    } else {      
+    } else {
       return '#/files/' . $action . '/' . $obj->page()->id() . '/' . urlencode($obj->filename());
     }
   } else if(is_a($obj, 'Page')) {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -72,12 +72,8 @@ function i($icon, $position = null) {
   if(is_string($icon)) {
     echo '<i class="icon' . r($position, ' icon-' . $position) . ' fa fa-' . $icon . '"></i>';
   } else if(is_a($icon, 'Page')) {
-    $blueprint = blueprint::find($icon);
-    if($i = $blueprint->icon()) {
-      i($i, 'left');
-    } else {
-      i('file-o', 'left');
-    }
+    $icon = blueprint::find($icon)->icon();
+    i($icon, 'left');
   } else if(is_a($icon, 'File')) {
 
     switch($icon->type()) {

--- a/app/lib/blueprint.php
+++ b/app/lib/blueprint.php
@@ -12,6 +12,7 @@ class Blueprint extends Obj {
   public $pages     = null;
   public $files     = null;
   public $deletable = true;
+  public $icon      = null;
   public $fields    = array();
 
   public function __construct($name) {
@@ -26,6 +27,7 @@ class Blueprint extends Obj {
     $this->title     = a::get($this->yaml, 'title', 'Page');
     $this->preview   = a::get($this->yaml, 'preview', 'page');
     $this->deletable = a::get($this->yaml, 'deletable', true);
+    $this->icon      = a::get($this->yaml, 'icon', null);
     $this->pages     = new Blueprint\Pages(a::get($this->yaml, 'pages', true));
     $this->files     = new Blueprint\Files(a::get($this->yaml, 'files', true));
 

--- a/app/lib/blueprint.php
+++ b/app/lib/blueprint.php
@@ -12,7 +12,7 @@ class Blueprint extends Obj {
   public $pages     = null;
   public $files     = null;
   public $deletable = true;
-  public $icon      = null;
+  public $icon      = 'file-o';
   public $fields    = array();
 
   public function __construct($name) {
@@ -27,7 +27,7 @@ class Blueprint extends Obj {
     $this->title     = a::get($this->yaml, 'title', 'Page');
     $this->preview   = a::get($this->yaml, 'preview', 'page');
     $this->deletable = a::get($this->yaml, 'deletable', true);
-    $this->icon      = a::get($this->yaml, 'icon', null);
+    $this->icon      = a::get($this->yaml, 'icon', 'file-o');
     $this->pages     = new Blueprint\Pages(a::get($this->yaml, 'pages', true));
     $this->files     = new Blueprint\Files(a::get($this->yaml, 'files', true));
 

--- a/app/views/dashboard/index.php
+++ b/app/views/dashboard/index.php
@@ -126,7 +126,7 @@
             <?php foreach($history as $item): ?>
             <li>
               <a title="<?php __($item->title()) ?>" href="<?php _u($item, 'show') ?>">
-                <?php i('file-o', 'left') . __($item->title()) ?>
+                <?php i($item) . __($item->title()) ?>
               </a>
             </li>
             <?php endforeach ?>


### PR DESCRIPTION
Adds the ability to specify a custom icon for the respective pages in a blueprint

```
title: Project
pages: true
icon: suitcase
files:
…
```
![screen shot 2015-05-31 at 20 29 54](https://cloud.githubusercontent.com/assets/3788865/7903172/74806b3c-07d4-11e5-9707-dd02960ae4ca.png)

![screen shot 2015-05-31 at 20 32 40](https://cloud.githubusercontent.com/assets/3788865/7903173/77de50be-07d4-11e5-85af-ba32bc54ad1b.png)

