### PR TITLE
License detection for old school beta licenses

### DIFF
--- a/app/panel.php
+++ b/app/panel.php
@@ -295,7 +295,7 @@ class Panel {
       $type = 'Kirby 2 Professional';
     } else if(str::startsWith($key, 'K2-PERSONAL') and str::length($key) == 44) {
       $type = 'Kirby 2 Personal';
-    } else if(str::length($key) == 32) {
+    } else if(str::length($key) == 32 or (str::startsWith($key, 'BETA') && str::length($key) == 9)) {
       $type = 'Kirby 1';
     } else {
       $key = null;

--- a/app/panel.php
+++ b/app/panel.php
@@ -295,7 +295,7 @@ class Panel {
       $type = 'Kirby 2 Professional';
     } else if(str::startsWith($key, 'K2-PERSONAL') and str::length($key) == 44) {
       $type = 'Kirby 2 Personal';
-    } else if(str::length($key) == 32 or (str::startsWith($key, 'BETA') && str::length($key) == 9)) {
+    } else if(str::length($key) == 32 or (str::startsWith($key, 'BETA') and str::length($key) == 9)) {
       $type = 'Kirby 1';
     } else {
       $key = null;


### PR DESCRIPTION
Hi!

If you remember, once Kirby 1 was released, you gave out Kirby licenses. Mine started with BETA and is a 9 characters long string. Pull Requesting this change since it bothers me in the Panel while I use my original license. 

:cupid: I do have a licence! :heartbeat: 