### PR TITLE
Remove empty option on select field when required.

### DIFF
--- a/app/fields/select/select.php
+++ b/app/fields/select/select.php
@@ -35,7 +35,9 @@ class SelectField extends BaseField {
       'disabled'     => $this->disabled(),
     ));
 
-    $select->append($this->option('', '', $this->value() == ''));
+    if (!$this->required()) {
+      $select->append($this->option('', '', $this->value() == ''));
+    }
 
     if($this->readonly()) {
       $select->attr('tabindex', '-1');


### PR DESCRIPTION
If the select field is set to required, I don't believe there should be an empty option.