### PR TITLE
word-break: break-all;

### DIFF
--- a/assets/scss/components/_form.scss
+++ b/assets/scss/components/_form.scss
@@ -288,6 +288,7 @@ fieldset {
   -ms-appearance: none;
   appearance: none;
   border-radius: 0;
+  word-break: break-all;
 }
 .input:focus {
   outline: 0;


### PR DESCRIPTION
Prevent long filenames flowing out of the box in the delete modal.

Before:

![screen shot 2015-09-06 at 15 04 05](https://cloud.githubusercontent.com/assets/1090876/9704482/f0e78f0e-54a8-11e5-89d8-2d405704372a.png)

After:

![screen shot 2015-09-06 at 15 07 20](https://cloud.githubusercontent.com/assets/1090876/9704486/0557c6c0-54a9-11e5-9771-5a8bf82789c7.png)
