### PR TITLE
Add page variable to structure

### DIFF
--- a/app/src/panel/models/page/structure.php
+++ b/app/src/panel/models/page/structure.php
@@ -52,6 +52,7 @@ class Structure {
         $fields[$name]['buttons'] = false;
       }
 
+      $fields[$name]["page"] = $this->page;
     }
 
     return $fields;

--- a/app/src/panel/models/page/structure.php
+++ b/app/src/panel/models/page/structure.php
@@ -8,6 +8,8 @@ use Obj;
 use Str;
 use Yaml;
 
+use Kirby\Panel\Models\Page\Blueprint\Fields;
+
 class Structure {
 
   protected $page;
@@ -37,26 +39,8 @@ class Structure {
   }
 
   public function fields() {
-    $fields = $this->config->fields();
-
-    // make sure that no unwanted options or fields 
-    // are being included here
-    foreach($fields as $name => $field) {
-
-      // remove all structure fields within structures
-      if($field['type'] == 'structure') {
-        unset($fields[$name]);
-
-      // remove all buttons from textareas
-      } else if($field['type'] == 'textarea') {
-        $fields[$name]['buttons'] = false;
-      }
-
-      $fields[$name]["page"] = $this->page;
-    }
-
-    return $fields;
-
+    $fields = new Fields($this->config->fields(), $this->page);
+    return $fields->toArray();
   }
 
   public function data() {


### PR DESCRIPTION
fixes #598

The structure->fields() should provide the page variable just like blueprint-fields()

see ``src/panel/models/page.php``

```
134:
public function structure($field) {
  return new Structure($this, $field);
}
```

```
153:
public function getFormFields() {
  return $this->blueprint()->fields($this)->toArray();
}
```
