### PR TITLE
Structure uses Fields class.

### DIFF
--- a/app/src/panel/models/page/structure.php
+++ b/app/src/panel/models/page/structure.php
@@ -37,28 +37,8 @@ class Structure {
   }
 
   public function fields() {
-    $fields = $this->config->fields();
-
-    // make sure that no unwanted options or fields 
-    // are being included here
-    foreach($fields as $name => $field) {
-
-      // remove all structure fields within structures
-      if($field['type'] == 'structure') {
-        unset($fields[$name]);
-
-      // remove all buttons from textareas
-      } else if($field['type'] == 'textarea') {
-        $fields[$name]['buttons'] = false;
-      }
-
-      // add the page to the fields
-      $fields[$name]['page'] = $this->page;
-
-    }
-
-    return $fields;
-
+    $fields = new Fields($this->config->fields(), $this->page);
+    return $fields->toArray();
   }
 
   public function data() {


### PR DESCRIPTION
Sorry for opening this structure thing again. But unfortunate this pull request is necessary for the builder field (https://github.com/TimOetting/kirby-builder/tree/develop). 
I rebuilt the field with the new form/styles/view structure. I was able to reuse and extend the structure field, but at one point I need to create a extended Structure class and to work properly this class fields needs to behave like blueprint fields. The change in this commit will make it possible and had the side effect that as far as i tested it, the structure field form then behaves exactly like the edit page form (like the buttons in the textarea field)

Cheers :v:  :smile: