### PR TITLE
Structure uses Fields class.

### DIFF
--- a/app/src/panel/models/page/structure.php
+++ b/app/src/panel/models/page/structure.php
@@ -8,6 +8,8 @@ use Obj;
 use Str;
 use Yaml;
 
+use Kirby\Panel\Models\Page\Blueprint\Fields;
+
 class Structure {
 
   protected $page;
@@ -47,18 +49,30 @@ class Structure {
       if($field['type'] == 'structure') {
         unset($fields[$name]);
 
-      // remove all buttons from textareas
+      // remove unsupported buttons from textareas
       } else if($field['type'] == 'textarea') {
-        $fields[$name]['buttons'] = false;
+
+        $buttons = $fields[$name]['buttons'];
+
+        if(is_array($buttons)) {
+
+          $index = array_search("email", $buttons);
+          if($index >= 0) array_splice($buttons, $index, 1);
+
+          $index = array_search("link", $buttons);
+          if($index >= 0) array_splice($buttons, array_search($index, $buttons), 1);
+
+          $fields[$name]['buttons'] = $buttons;
+
+        } else if($buttons == null)
+
+          $fields[$name]['buttons'] = ["bold", "italic"];
+
       }
-
-      // add the page to the fields
-      $fields[$name]['page'] = $this->page;
-
     }
 
-    return $fields;
-
+    $fields = new Fields($fields, $this->page);
+    return $fields->toArray();
   }
 
   public function data() {


### PR DESCRIPTION
Sorry for opening this structure thing again. But unfortunate this pull request is necessary for the builder field (https://github.com/TimOetting/kirby-builder/tree/develop). 
I rebuilt the field with the new form/styles/view structure. I was able to reuse and extend the structure field, but at one point I need to create a extended Structure class and to work properly this class fields needs to behave like blueprint fields. The change in this commit will make it possible and had the side effect that as far as i tested it, the structure field form then behaves exactly like the edit page form (like the buttons in the textarea field)

Cheers :v:  :smile: