### PR TITLE
Adds the ability to have more than one custom css and js in form plugins.

### DIFF
--- a/app/src/panel/form/plugins.php
+++ b/app/src/panel/form/plugins.php
@@ -76,7 +76,7 @@ class Plugins {
       $output[] = f::read(dirname($root) . DS . 'assets' . DS . $type . DS . $filename);          
     }
 
-    $this->{$type} = implode(PHP_EOL . PHP_EOL, $output);
+    $this->{$type} .= implode(PHP_EOL . PHP_EOL, $output);
 
   }
 

--- a/app/src/panel/models/site.php
+++ b/app/src/panel/models/site.php
@@ -63,6 +63,10 @@ class Site extends \Site {
 
   }
 
+  public function getBlueprintFields() {
+    return $this->blueprint()->fields($this);
+  }
+
   public function getFormFields() {
     return $this->blueprint()->fields($this)->toArray();
   }

--- a/app/src/panel/structure.php
+++ b/app/src/panel/structure.php
@@ -76,13 +76,33 @@ class Structure {
     // are being included here
     foreach($fields as $name => $field) {
 
+      // skip fields without type
+      if(!isset($field['type']))
+        continue;
+
       // remove all structure fields within structures
       if($field['type'] == 'structure') {
         unset($fields[$name]);
 
-      // remove all buttons from textareas
+      // remove unsupported buttons from textareas
       } else if($field['type'] == 'textarea') {
-        $fields[$name]['buttons'] = false;
+
+        $buttons = $fields[$name]['buttons'];
+
+        if(is_array($buttons)) {
+
+          $index = array_search("email", $buttons);
+          if($index >= 0) array_splice($buttons, $index, 1);
+
+          $index = array_search("link", $buttons);
+          if($index >= 0) array_splice($buttons, array_search($index, $buttons), 1);
+
+          $fields[$name]['buttons'] = $buttons;
+
+        } else if($buttons == null)
+
+          $fields[$name]['buttons'] = ["bold", "italic"];
+
       }
 
     }


### PR DESCRIPTION
the ``assets()`` function did override the ``js`` and ``css`` if you had more than one custom field.

And I added the supported buttons to the textarea in the structure field. Also the php console threw a ``Illegal string offset 'type'`` warning if you used a field that was set with the new "field snippet" feature.
Maybe i finally get my structure pull request. hehehe :laughing: