### PR TITLE
Fix #601

### DIFF
--- a/app/src/panel/models/page.php
+++ b/app/src/panel/models/page.php
@@ -101,7 +101,7 @@ class Page extends \Page {
   }
 
   public function url($action = null) {
-    if(empty($action)) {
+    if(empty($action) or $lang = $this->site->language($action)) {
       return parent::url();
     } else if($action == 'preview') {
       if($previewSetting = $this->blueprint()->preview()) {


### PR DESCRIPTION
Cause the `url` method of the multilang page class which is called in line 105 of the panel page model ( https://github.com/getkirby/panel/blob/develop/app/src/panel/models/page.php#L105) calls itself on line 132 (https://github.com/getkirby/kirby/blob/develop/branches/multilang/page.php#L132), but this call ends up in the panel page model class, not the basic core multilang class.

And it passes the `$lang` code which currently is interpreted as an `$action` by the panel page model method. So therefore, instead of just testing for `empty($action)` one solution would be test if `$action` is a language code instead.

Other way would be to ensure that this call https://github.com/getkirby/kirby/blob/develop/branches/multilang/page.php#L132 won't end up in the panel model. But I haven't found a working solution for that so far.

