### PR TITLE
Fix #617

### DIFF
--- a/app/src/panel/collections/children.php
+++ b/app/src/panel/collections/children.php
@@ -53,8 +53,8 @@ class Children extends \Children {
     $blueprint = new Blueprint($template);
     $data      = array();
 
-    foreach($blueprint->fields() as $key => $field) {
-      $data[$key] = $field->default();        
+    foreach($blueprint->fields(null) as $key => $field) {
+      $data[$key] = $field->default();
     }
 
     $data = array_merge($data, $content);


### PR DESCRIPTION
`$blueprint->fields` now requires `$model` as parameter. But since the page hasn't been created yet, it might suit to just pass `null` – seems to work in regards of #617