### PR TITLE
Textarea field extends Textfield instead BaseField

### DIFF
--- a/app/fields/textarea/textarea.php
+++ b/app/fields/textarea/textarea.php
@@ -1,6 +1,6 @@
 <?php
 
-class TextareaField extends InputField {
+class TextareaField extends TextField {
 
   static public $assets = array(
     'js' => array(


### PR DESCRIPTION
As came up in this discussion (https://github.com/getkirby/panel/pull/596), it seems to be more logical that the TextareaField extends the TextField not just the BaseField.

With that change, changes to the TextField as suggested by the feature PR would refer much more logically to all text field types.