### PR TITLE
Made more error messages translatable

### DIFF
--- a/app/controllers/error.php
+++ b/app/controllers/error.php
@@ -7,7 +7,7 @@ class ErrorController extends Kirby\Panel\Controllers\Base {
     $this->auth();
 
     if(is_null($text)) {
-      $text = 'The page could not be found';
+      $text = l('pages.error.missing');
     }
 
     if(server::get('HTTP_MODAL')) {

--- a/app/fields/structure/controller.php
+++ b/app/fields/structure/controller.php
@@ -35,7 +35,7 @@ class StructureFieldController extends Kirby\Panel\Controllers\Field {
 
     if(!$entry) {
       return $this->modal('error', array(
-        'text' => 'The item could not be found'
+        'text' => l('fields.structure.entry.error')
       ));
     }
 
@@ -68,7 +68,7 @@ class StructureFieldController extends Kirby\Panel\Controllers\Field {
 
     if(!$entry) {
       return $this->modal('error', array(
-        'text' => 'The item could not be found'
+        'text' => l('fields.structure.entry.error')
       ));
     }
 

--- a/app/languages/de.php
+++ b/app/languages/de.php
@@ -18,6 +18,16 @@ return array(
     'insert' => 'Einfügen',
     'ok' => 'Ok',
 
+    // routes
+    'routes.error.invalid' => 'Ungültige Panel-URL',
+
+    // controllers
+    'controller.error.invalid' => 'Ungültiger Controller',
+    'controller.error.action' => 'Ungültige Aktion',
+
+    // views
+    'view.error.invalid' => 'Ungültiger View: ',
+
     // options (sidebar)
     'options.show' => 'Optionen einblenden',
     'options.hide' => 'Optionen ausblenden',
@@ -48,9 +58,13 @@ return array(
     'login.password.label' => 'Passwort',
     'login.error' => 'Ungültiger Benutzername oder Passwort',
     'login.button' => 'Anmelden',
+    'login.log.error.permissions' => 'Die Anmeldelog-Datei ist nicht beschreibbar.'
 
     // logout
     'logout' => 'Abmelden',
+
+    // topbar
+    'topbar.error.class.definition' => 'Fehlende Topbar-Definition für Klasse: ',
 
     // dashboard
     'dashboard' => 'Übersicht',
@@ -110,6 +124,7 @@ return array(
     'pages.add.url.close' => 'Schließen',
     'pages.add.url.help' => 'Format: Kleinbuchstaben a-z, 0-9 und Bindestriche',
     'pages.add.template.label' => 'Vorlage',
+    'pages.add.error.create' => 'Die Seite konnte nicht hinzugefügt werden',
     'pages.add.error.title' => 'Der Titel fehlt',
     'pages.add.error.template' => 'Die Vorlage fehlt',
     'pages.add.error.max.headline' => 'Keine weiteren Unterseiten zugelassen',
@@ -150,6 +165,7 @@ return array(
     'subpages.index.invisible' => 'Unsichtbare Seiten',
     'subpages.index.invisible.help' => 'Ziehe sichtbare Seiten hierher, um sie unsichtbar zu machen',
     'subpages.add.error' => 'Keine Unterseiten für diese Seite zugelassen',
+    'subpages.add.error.more' => 'Diese Seite kann keine weiteren Unterseiten haben',
     'subpages.error.missing' => 'Die Seite konnte nicht gefunden werden.',
 
     // files
@@ -163,6 +179,14 @@ return array(
     'files.index.delete' => 'Löschen',
     'files.index.error.disabled' => 'Keine Dateien für diese Seite zugelassen',
     'files.add.error.max' => 'Die maximale Anzahl an Dateien für die aktuelle Seite ist erreicht.',
+    'files.add.error.extension.missing' => 'Du kannst keine Dateien ohne Dateiendung hochladen',
+    'files.add.error.extension.forbidden' => 'Verbotene Dateiendung',
+    'files.add.error.mime.forbidden' => 'Verbotener MIME-Typ',
+    'files.add.error.htaccess' => 'htaccess-Dateien können nicht hochgeladen werden',
+    'files.add.error.invisible' => 'Versteckte Dateien können nicht hochgeladen werden',
+    'files.add.blueprint.type.error' => 'Seite erlaubt nur: ',
+    'files.add.blueprint.size.error' => 'Seite erlaubt nur eine Dateigröße von ',
+
     'files.show.name.label' => 'Dateiname',
     'files.show.info.label' => 'Typ / Größe / Abmessungen',
     'files.show.link.label' => 'Öffentlicher Link',
@@ -218,18 +242,25 @@ return array(
     'users.form.error.permissions.text' => 'Bitte stelle sicher, dass /site/accounts besteht und beschreibbar ist.',
     'users.delete.headline' => 'Willst du diesen Benutzer wirklich löschen?',
     'users.delete.error' => 'Der Benutzer konnte nicht gelöscht werden',
-    'users.delete.error.rights' => 'Du kannst diesen Benutzer nicht löschen',
+    'users.delete.error.permission' => 'Du kannst keine Benutzer löschen',
+    'users.delete.error.permission.single' => 'Du kannst diesen Benutzer nicht löschen',
     'users.delete.error.lastadmin' => 'Du kannst den letzten Admin nicht löschen',
     'users.avatar.drop' => 'Ziehe ein Profilbild hierher…',
     'users.avatar.click' => '…oder klicke, um ein Profilbild hochzuladen',
     'users.avatar.error.type' => 'Es sind nur JPG, PNG und GIF Dateien erlaubt.',
     'users.avatar.error.folder.headline' => 'Der Profilbild Ordner ist nicht beschreibbar',
     'users.avatar.error.folder.text' => 'Bitte erstelle den Ordner <strong>/assets/avatars</strong> und stelle sicher, dass er beschreibbar ist.',
+    'users.avatar.error.permission' => 'Du darfst den Avatar nicht verändern',
     'users.avatar.delete.error' => 'Das Profilbild konnte nicht gelöscht werden',
+    'users.avatar.delete.error.permission' => 'Du darfst den Avater dieses Users nicht löschen',
     'users.avatar.delete.success' => 'Das Profilbild wurde gelöscht',
     'users.avatar.missing' => 'Der Benutzer hat kein Profilbild',
     'users.error.missing' => 'Der Benutzer wurde nicht gefunden',
     'user.error.lastadmin' => 'Du bist der letzte Admin. Das kann nicht verändert werden.',
+
+    // form
+    'form.error.missing' => 'Das Formular kann nicht gefunden werden',
+    'form.construct.error.invalid' => 'Ungültiger Formularkonstruktor',
 
     // form fields
     'fields.required' => 'Pflichtfeld',
@@ -276,6 +307,7 @@ return array(
     'fields.structure.add' => 'Hinzufügen',
     'fields.structure.add.first' => 'Füge den ersten Eintrag hinzu',
     'fields.structure.empty' => 'Es bestehen keine Einträge.',
+    'fields.structure.entry.error' = > 'Der Eintrag konnte nicht gefunden werden',
     'fields.structure.cancel' => 'Abbrechen',
     'fields.structure.save' => 'Ok',
     'fields.structure.edit' => 'Bearbeiten',
@@ -298,6 +330,7 @@ return array(
     'fields.error.missing.controller' => 'Die Feldcontroller-Datei fehlt',
     'fields.error.missing.class' => 'Die Feldcontroller-Klasse fehlt',
     'fields.error.route.invalid' => 'Ungültige Feld-Route',
+    'fields.error.extended' => 'Das Feld kann nicht erweitert werden',
 
     // textarea overlays
     'editor.link.url.label' => 'URL einfügen',
@@ -309,6 +342,12 @@ return array(
     'editor.email.text.help' => 'Der Linktext ist optional',
     'editor.file.empty' => 'Diese Seite hat keine Dateien',
     'editor.image.empty' => 'Diese Seite hat keine Bilder',
+
+    // autocomplete
+    'autocomplete.method.error' => 'Ungültige Autocomplete-Methode',
+
+    // blueprints
+    'blueprints.error.default.missing' => 'Standard-Blueprint fehlt',
 
     // error page
     'error' => 'Fehler',

--- a/app/languages/en.php
+++ b/app/languages/en.php
@@ -18,6 +18,16 @@ return array(
     'insert' => 'Insert',
     'ok' => 'Ok',
 
+    // routes
+    'routes.error.invalid' => 'Invalid Panel URL',
+
+    // controllers
+    'controller.error.invalid' => 'Invalid controller',
+    'controller.error.action' => 'Invalid action',
+
+    // views
+    'view.error.invalid' => 'Invalid view: ',
+
     // options (sidebar)
     'options.show' => 'Show options',
     'options.hide' => 'Hide options',
@@ -48,9 +58,13 @@ return array(
     'login.password.label' => 'Password',
     'login.error' => 'Invalid username or password',
     'login.button' => 'Login',
+    'login.log.error.permissions' => 'Login log file is not writable.'
 
     // logout
     'logout' => 'Logout',
+
+    // topbar
+    'topbar.error.class.definition' => 'Missing topbar definition for class: ',
 
     // dashboard
     'dashboard' => 'Dashboard',
@@ -111,6 +125,7 @@ return array(
     'pages.add.url.close' => 'Close',
     'pages.add.url.help' => 'Format: lowercase a-z, 0-9 and regular dashes',
     'pages.add.template.label' => 'Template',
+    'pages.add.error.create' => 'The page could not be created',
     'pages.add.error.title' => 'The title is missing',
     'pages.add.error.template' => 'The template is missing',
     'pages.add.error.max.headline' => 'No new pages allowed',
@@ -151,6 +166,7 @@ return array(
     'subpages.index.invisible' => 'Invisible pages',
     'subpages.index.invisible.help' => 'Drag visible pages here to unsort them/make them invisible.',
     'subpages.add.error' => 'This page is not allowed to have subpages',
+    'subpages.add.error.more' => 'This page cannot have any more subpages',
     'subpages.error.missing' => 'The page could not be found',
 
     // files
@@ -164,6 +180,13 @@ return array(
     'files.index.delete' => 'Delete',
     'files.index.error.disabled' => 'The page is not allowed to have any files',
     'files.add.error.max' => 'The maximum number of files for the current page has been reached.',
+    'files.add.error.extension.missing' => 'You cannot upload files without extension',
+    'files.add.error.extension.forbidden' => 'Forbidden file extension',
+    'files.add.error.mime.forbidden' => 'Forbidden mime type',
+    'files.add.error.htaccess' => 'htaccess files cannot be uploaded',
+    'files.add.error.invisible' => 'Invisible files cannot be uploaded',
+    'files.add.blueprint.type.error' => 'Page only allows: ',
+    'files.add.blueprint.size.error' => 'Page only allows file size of ',
     'files.show.name.label' => 'Filename',
     'files.show.info.label' => 'Type / Size / Dimensions',
     'files.show.link.label' => 'Public link',
@@ -219,18 +242,25 @@ return array(
     'users.form.error.permissions.text' => 'Please make sure that /site/accounts exists and is writable.',
     'users.delete.headline' => 'Do you really want to delete this user?',
     'users.delete.error' => 'The user could not be deleted',
-    'users.delete.error.rights' => 'You are not allowed to delete this user',
+    'users.delete.error.permission' => 'You are not allowed to delete users',
+    'users.delete.error.permission.single' => 'You are not allowed to delete this user',
     'users.delete.error.lastadmin' => 'You cannot delete the last admin',
     'users.avatar.drop' => 'Drop a profile picture here…',
     'users.avatar.click' => '…or click to upload',
     'users.avatar.error.type' => 'You can only upload JPG, PNG and GIF files',
     'users.avatar.error.folder.headline' => 'The avatar folder is not writable',
     'users.avatar.error.folder.text' => 'Please create the folder <strong>/assets/avatars</strong> and make it writable to upload profile pictures.',
+    'users.avatar.error.permission' => 'You are not allowed to change the avatar',
     'users.avatar.delete.error' => 'The profile picture could not be deleted',
+    'users.avatar.delete.error.permission' => 'You are not allowed to delete the avatar of this user',
     'users.avatar.delete.success' => 'The profile picture has been deleted',
     'users.avatar.missing' => 'This user has no avatar',
     'users.error.missing' => 'The user could not be found',
     'user.error.lastadmin' => 'You are the only admin. This cannot be changed.',
+
+    // form
+    'form.error.missing' => 'The form cannot be found',
+    'form.construct.error.invalid' => 'Invalid form construction method',
 
     // form fields
     'fields.required' => 'Required',
@@ -277,6 +307,7 @@ return array(
     'fields.structure.add' => 'Add',
     'fields.structure.add.first' => 'Add the first entry',
     'fields.structure.empty' => 'No entries yet.',
+    'fields.structure.entry.error' = > 'The item could not be found',
     'fields.structure.cancel' => 'Cancel',
     'fields.structure.save' => 'Ok',
     'fields.structure.edit' => 'Edit',
@@ -299,6 +330,7 @@ return array(
     'fields.error.missing.controller' => 'The field controller file is missing',
     'fields.error.missing.class' => 'The field controller class is missing',
     'fields.error.route.invalid' => 'Invalid field route',
+    'fields.error.extended' => 'The field cannot be extended',
 
     // textarea overlays
     'editor.link.url.label' => 'Insert URL',
@@ -310,6 +342,12 @@ return array(
     'editor.email.text.help' => 'The link text is optional',
     'editor.file.empty' => 'This page has no files',
     'editor.image.empty' => 'This page has no images',
+
+    // autocomplete
+    'autocomplete.method.error' => 'Invalid autocomplete method',
+
+    // blueprints
+    'blueprints.error.default.missing' => 'Missing default blueprint',
 
     // error page
     'error' => 'Error',

--- a/app/src/panel.php
+++ b/app/src/panel.php
@@ -264,7 +264,7 @@ class Panel {
     if($page = (empty($id) or $id == '/') ? $this->site() : $this->site()->find($id)) {
       return $page;
     } else {
-      throw new Exception('The page could not be found');
+      throw new Exception(l('pages.error.missing'));
     }
   }
 
@@ -290,13 +290,13 @@ class Panel {
     }
 
     if(!file_exists($file)) {
-      throw new Exception('The form cannot be found');
+      throw new Exception(l('form.error.missing'));
     }
 
     $callback = require($file);
 
     if(!is_callable($callback)) {
-      throw new Exception('Invalid form construction method');
+      throw new Exception(l('form.construct.error.invalid'));
     }
 
     $form = call($callback, $data);
@@ -387,7 +387,7 @@ class Panel {
 
       // react on invalid routes
       if(!$this->route) {
-        throw new Exception('Invalid Panel URL');
+        throw new Exception(l('routes.error.invalid'));
       }
 
       if(is_callable($this->route->action())) {
@@ -432,7 +432,7 @@ class Panel {
 
     // react on missing controllers
     if(!file_exists($controllerFile)) {
-      throw new Exception('Invalid controller');
+      throw new Exception(l('controller.error.invalid'));
     }
 
     // load the controller
@@ -440,7 +440,7 @@ class Panel {
 
     // check for the called action
     if(!method_exists($controllerName, $controllerAction)) {
-      throw new Exception('Invalid action');
+      throw new Exception(l('controller.error.action'));
     }
 
     // run the controller
@@ -544,7 +544,7 @@ class Panel {
     if($user = $this->site()->user($username)) {
       return $user;
     } else {
-      throw new Exception('The user could not be found');
+      throw new Exception(l('users.error.missing'));
     }
   }
 

--- a/app/src/panel/autocomplete.php
+++ b/app/src/panel/autocomplete.php
@@ -24,7 +24,7 @@ class Autocomplete {
     $method = 'autocomplete' . $this->method;
 
     if(!method_exists($this, $method)) {
-      throw new Exception('Invalid autocomplete method');
+      throw new Exception(l('autocomplete.method.error'));
     }
 
     $result = array_values((array)$this->$method($this->params));

--- a/app/src/panel/collections/children.php
+++ b/app/src/panel/collections/children.php
@@ -63,7 +63,7 @@ class Children extends \Children {
     $page = new Page($this->page, parent::create($uid, $template, $data)->dirname());
 
     if(!$page) {
-      throw new Exception('The page could not be created');
+      throw new Exception(l('pages.add.error.create'));
     }
 
     // subpage builder

--- a/app/src/panel/login.php
+++ b/app/src/panel/login.php
@@ -40,7 +40,7 @@ class Login {
 
     // make sure the logroot exists
     if(!is_writable(dirname($this->logfile))) {
-      throw new Exception('The accounts folder is not writable.');
+      throw new Exception(l('users.form.error.permissions.title'));
     }
 
     // create the logfile if not there yet
@@ -48,7 +48,7 @@ class Login {
 
     // make sure the logroot exists
     if(!is_writable($this->logfile)) {
-      throw new Exception('Login log file is not writable.');
+      throw new Exception(l('login.log.error.permissions'));
     }
 
   }
@@ -67,13 +67,13 @@ class Login {
     try {
 
       if($this->isInvalidUsername() || $this->isInvalidPassword()) {
-        throw new Exception('Invalid username or password');
+        throw new Exception(l('login.error'));
       }
       
       $user = $this->user();      
       
       if(!$user->login($this->password)) {
-        throw new Exception('Invalid username or password');
+        throw new Exception(l('login.error'));
       }
   
       $this->clearLog($this->visitorId());

--- a/app/src/panel/models/page/addbutton.php
+++ b/app/src/panel/models/page/addbutton.php
@@ -13,7 +13,7 @@ class AddButton extends Obj {
     $this->url   = $this->page->url('add');
 
     if(!$this->page->canHaveMoreSubpages()) {
-      throw new Exception('This page cannot have any more subpages');
+      throw new Exception(l('subpages.add.error.more'));
     }
 
   }  

--- a/app/src/panel/models/page/blueprint.php
+++ b/app/src/panel/models/page/blueprint.php
@@ -80,7 +80,7 @@ class Blueprint extends Obj {
       return true;
 
     } else if($name == 'default') {
-      throw new Exception('Missing default blueprint');
+      throw new Exception(l('blueprints.error.default.missing'));
     } else {
       return $this->load('default');
     }

--- a/app/src/panel/models/page/blueprint/field.php
+++ b/app/src/panel/models/page/blueprint/field.php
@@ -58,7 +58,7 @@ class Field extends Obj {
     $files   = glob(kirby()->roots()->blueprints() . DS . 'fields' . DS . $extends . '.{yml,yaml,php}', GLOB_BRACE);
 
     if(empty($files)) {
-      throw new Exception('The field cannot be extended');
+      throw new Exception(l('fields.error.extended'));
     }
 
     $yaml   = data::read($files[0], 'yaml');

--- a/app/src/panel/models/page/uploader.php
+++ b/app/src/panel/models/page/uploader.php
@@ -96,7 +96,7 @@ class Uploader {
     // delete the upload if something went wrong
     if(!$file) {
       $uploaded->delete();
-      throw new Exception('The file could not be found');
+      throw new Exception(l('files.error.missing.file'));
     }
 
     try {
@@ -119,42 +119,42 @@ class Uploader {
 
     // files without extension are not allowed
     if(empty($extension)) {
-      throw new Exception('You cannot upload files without extension');
+      throw new Exception(l('files.add.error.extension.missing'));
     }
 
     // block forbidden extensions
     if(in_array($extension, $forbiddenExtensions)) {
-      throw new Exception('Forbidden file extension');
+      throw new Exception(l('files.add.error.extension.forbidden'));
     }
 
     // especially block any connection that contains php
     if(str::contains($extension, 'php')) {
-      throw new Exception('Forbidden file extension');
+      throw new Exception(l('files.add.error.extension.forbidden'));
     }
 
     // block forbidden mimes
     if(in_array(strtolower($file->mime()), $forbiddenMimes)) {
-      throw new Exception('Forbidden mime type');
+      throw new Exception(l('files.add.error.mime.forbidden'));
     }
-    
+
     // Block htaccess files
     if(strtolower($file->filename()) == '.htaccess') {
-      throw new Exception('htaccess files cannot be uploaded');
+      throw new Exception(l('files.add.error.htaccess'));
     }
 
     // Block invisible files
     if(str::startsWith($file->filename(), '.')) {
-      throw new Exception('Invisible files cannot be uploaded');
+      throw new Exception(l('files.add.error.invisible'));
     }
 
     // Files blueprint option 'type'
     if(count($filesettings->type()) > 0 and !in_array($file->type(), $filesettings->type())) {
-      throw new Exception('Page only allows: ' . implode(', ', $filesettings->type()));
+      throw new Exception(l('files.add.blueprint.type.error') . implode(', ', $filesettings->type()));
     }
 
-    // Files blueprint option 'size' 
+    // Files blueprint option 'size'
     if($filesettings->size() and f::size($file->root()) > $filesettings->size()) {
-      throw new Exception('Page only allows file size of ' . f::niceSize($filesettings->size()));
+      throw new Exception(l('files.add.blueprint.size.error') . f::niceSize($filesettings->size()));
     }
 
     // Files blueprint option 'width'

--- a/app/src/panel/models/user.php
+++ b/app/src/panel/models/user.php
@@ -29,7 +29,7 @@ class User extends \User {
   public function update($data = array()) {
 
     if(!panel()->user()->isAdmin() and !$this->isCurrent()) {
-      throw new Exception(l('users.form.error.update.rights'));
+      throw new Exception(l('users.form.error.update.permission.single'));
     }
 
     if(str::length(a::get($data, 'password')) > 0) {
@@ -67,7 +67,7 @@ class User extends \User {
   public function delete() {
 
     if(!panel()->user()->isAdmin() and !$this->isCurrent()) {
-      throw new Exception('You are not allowed to delete users');
+      throw new Exception(l('users.form.error.update.permission'));
     }
 
     if($this->isLastAdmin()) {

--- a/app/src/panel/models/user/avatar.php
+++ b/app/src/panel/models/user/avatar.php
@@ -37,7 +37,7 @@ class Avatar extends Media {
   public function upload() {
 
     if(!panel()->user()->isAdmin() and !$this->user->isCurrent()) {
-      throw new Exception('You are not allowed to change the avatar');
+      throw new Exception(l('users.avatar.error.permission'));
     }
 
     $root = $this->exists() ? $this->root() : $this->user->avatarRoot('{safeExtension}');
@@ -71,7 +71,7 @@ class Avatar extends Media {
   public function delete() {
 
     if(!panel()->user()->isAdmin() and !$this->user->isCurrent()) {
-      throw new Exception('You are not allowed to delete the avatar of this user');
+      throw new Exception(l('users.avatar.delete.error.permission'));
     } else if(!$this->exists()) {
       return true;
     }

--- a/app/src/panel/topbar.php
+++ b/app/src/panel/topbar.php
@@ -32,7 +32,7 @@ class Topbar {
         $callback($this, $input);
 
       } else {
-        throw new Exception('Missing topbar definition for class: ' . $class);
+        throw new Exception(l('topbar.error.class.definition') . $class);
       }
 
     }

--- a/app/src/panel/view.php
+++ b/app/src/panel/view.php
@@ -25,7 +25,7 @@ class View {
 
   public function render() {
     $file = $this->_root . DS . str_replace('.', DS, $this->_file) . '.php';
-    if(!file_exists($file)) throw new Exception('Invalid view: ' . $file);
+    if(!file_exists($file)) throw new Exception(l('view.error.invalid') . $file);
     return tpl::load($file, $this->_data);
   }
 


### PR DESCRIPTION
Some are still missing that incorporate variables. Maybe we should find a way to work with some kind of placeholders in language strings.

Maybe something like:

'language.string' => 'This file is {{1}} px wide and {{2}} big'

and then

l('language.string', array(300, '12 Kb'))