### PR TITLE
Fix error when clicking link without »href« attribute.

### DIFF
--- a/assets/js/src/app.js
+++ b/assets/js/src/app.js
@@ -37,7 +37,7 @@ var app = {
     $(document).on('click', 'a', function(e) {      
 
       var link = $(this);
-      var href = link.attr('href');
+      var href = link.attr('href') || "";
 
       if(link.is('[data-dropdown]') || href.match(/^#/)) {
         return true;


### PR DESCRIPTION
Some external JavaScript components like CodeMirrir use `<a>` tags without the `href` attribute for generating toolbar-buttons etc.