### PR TITLE
Add option to select a page's grandchildren

### DIFF
--- a/app/src/panel/form/fieldoptions.php
+++ b/app/src/panel/form/fieldoptions.php
@@ -166,6 +166,7 @@ class FieldOptions {
         $items = $items->sortBy('title', 'asc');
         break;
       case 'children':
+      case 'grandchildren':
       case 'files':
       case 'images':
       case 'documents':


### PR DESCRIPTION
Add the grandchildren option to the fieldoptions array to be consistent with the other children/sibling/... selectors for the page (as in the docs)