### PR TITLE
Fixes an error, when clicking »Show/Download« in context menu

### DIFF
--- a/assets/js/src/jquery/plugins/jquery.context.js
+++ b/assets/js/src/jquery/plugins/jquery.context.js
@@ -12,7 +12,7 @@ var Context = function() {
     if(e.keyCode == 27) $(this).trigger('click.contextmenu');
   });
 
-  $(document).on('click', '.contextmenu', function() {
+  $(document).on('click', '.contextmenu', function(e) {
     e.stopPropagation();
   });
 


### PR DESCRIPTION
The event parameter `e` was missing in the callback function definition.