### PR TITLE
Add missing `use` statement in upload.php

### DIFF
--- a/app/src/panel/upload.php
+++ b/app/src/panel/upload.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Panel;
 
+use F;
+
 class Upload extends \Upload {
 
   protected function messages() {


### PR DESCRIPTION
Uploading a file that is too large causes an error because the call to `f::niceSize` tries to load class `\Kirby\Panel\f` when it should be loading `\f`.

To reproduce, upload a file that is larger than the PHP max upload size (but smaller than Apache/Nginx's max upload size). Panel should give you an error, but instead nothing happens. If you look at the request in Chrome Dev Tools, you'll see this error:

    <b>Fatal error</b>:  Class 'Kirby\Panel\f' not found in <b>.../panel/app/src/panel/upload.php</b> on line <b>14</b><br />