### PR TITLE
add DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 /assets/scss/.sass-cache
 /node_modules


### PR DESCRIPTION
on mac if you accidentaly visit the panel you add those files and make the submodule dirty