### PR TITLE
Apply the number field validation even if min=0

### DIFF
--- a/app/fields/number/number.php
+++ b/app/fields/number/number.php
@@ -8,7 +8,7 @@ class NumberField extends InputField {
     $this->label       = l::get('fields.number.label', 'Number');
     $this->placeholder = l::get('fields.number.placeholder', '#');
     $this->step        = 1;
-    $this->min         = 0;
+    $this->min         = false;
     $this->max         = false;
 
   }

--- a/app/fields/number/number.php
+++ b/app/fields/number/number.php
@@ -28,8 +28,8 @@ class NumberField extends InputField {
     if($this->validate and is_array($this->validate)) {
       return parent::validate();
     } else {
-      if($this->min and !v::min($this->result(), $this->min)) return false;
-      if($this->max and !v::max($this->result(), $this->max)) return false;
+      if(is_numeric($this->min) and !v::min($this->result(), $this->min)) return false;
+      if(is_numeric($this->max) and !v::max($this->result(), $this->max)) return false;
     }
 
     return true;


### PR DESCRIPTION
The value of `$this->min` is `0` by default, which is falsy. That's why that validation actually never applied.

WARNING: This is a breaking change because until now negative values worked even though the default minimum is set to `0`. This value will need to be manually set to `false` in the blueprint to allow negative values in the future. It was a bug, but this may lead to another one. ;)
Maybe the default value should be changed to `false` anyway.