### PR TITLE
Only show Language Toggle if >1 Language available

### DIFF
--- a/app/snippets/languages.php
+++ b/app/snippets/languages.php
@@ -1,4 +1,4 @@
-<?php if($languages): ?>
+<?php if($languages->count() > 1): ?>
 
 <div class="languages">
 


### PR DESCRIPTION
As the single- to multi-language conversion is not yet handled by kirby it can be nice to have the Setup described here https://getkirby.com/docs/languages/setup from the beginning even if you just start with one language and want to switch to a multi-language setup later.

Also showing a Switch with just one Option does not seem to make too much sense.