### PR TITLE
Fieldoptions from Field

### DIFF
--- a/app/src/panel/form/fieldoptions.php
+++ b/app/src/panel/form/fieldoptions.php
@@ -68,7 +68,7 @@ class FieldOptions {
     $defaults = array(
       'page'      => $this->field->page ? $this->field->page->id() : '',
       'name'      => 'tags',
-      'seperator' => ',',
+      'separator' => ',',
     );
 
     // sanitize the query
@@ -83,7 +83,7 @@ class FieldOptions {
     // ../
     // ../../ etc.
     $page    = $this->page($field['page']);
-    $items   = $page->{$field['name']}()->split($field['seperator']);
+    $items   = $page->{$field['name']}()->split($field['separator']);
     $options = array();
 
     foreach($items as $item) {
@@ -113,8 +113,8 @@ class FieldOptions {
 
     // merge the default parameters with the actual query
     $query = array_merge($defaults, $query);
-    
-    // dynamic page option 
+
+    // dynamic page option
     // ../
     // ../../ etc.
     $page    = $this->page($query['page']);
@@ -136,7 +136,7 @@ class FieldOptions {
       $text  = $this->tpl($query['text'], $item);
 
       $options[$value] = $text;
-    }    
+    }
 
     return $options;
 
@@ -146,7 +146,7 @@ class FieldOptions {
 
     if(str::startsWith($uri, '../')) {
       if($currentPage = $this->field->page) {
-        $path = $uri; 
+        $path = $uri;
         while(str::startsWith($path, '../')) {
           if($parent = $currentPage->parent()) {
             $currentPage = $parent;
@@ -155,14 +155,14 @@ class FieldOptions {
           }
           $path = str::substr($path, 3);
         }
-        $page = $currentPage;          
+        $page = $currentPage;
       } else {
         $page = null;
       }
     } else if($uri == '/') {
       $page = site();
     } else {
-      $page = page($uri);        
+      $page = page($uri);
     }
 
     return $page;
@@ -193,9 +193,9 @@ class FieldOptions {
   }
 
   public function isUrl($url) {
-    return 
-      v::url($url) or 
-      str::contains($url, '://localhost') or 
+    return
+      v::url($url) or
+      str::contains($url, '://localhost') or
       str::contains($url, '://127.0.0.1');
   }
 
@@ -238,7 +238,7 @@ class FieldOptions {
       case 'archives':
         $items = $page->{$method}();
         break;
-      default: 
+      default:
         $items = new Collection();
     }
 

--- a/app/src/panel/form/fieldoptions.php
+++ b/app/src/panel/form/fieldoptions.php
@@ -27,6 +27,8 @@ class FieldOptions {
       $this->options = $this->optionsFromApi($this->field->options);
     } else if($this->field->options == 'query') {
       $this->options = $this->optionsFromQuery($this->field->query);
+    } else if($this->field->options == 'field') {
+      $this->options = $this->optionsFromField($this->field->field);
     } else {
       $this->options = $this->optionsFromPageMethod($this->field->page, $this->field->options);
     }
@@ -58,6 +60,38 @@ class FieldOptions {
     $response = remote::get($url);
     $options  = @json_decode($response->content(), true);
     return is_array($options) ? $options : array();
+  }
+
+  public function optionsFromField($field) {
+
+    // default field parameters
+    $defaults = array(
+      'page'      => $this->field->page ? $this->field->page->id() : '',
+      'name'      => 'tags',
+      'seperator' => ',',
+    );
+
+    // sanitize the query
+    if(!is_array($field)) {
+      $field = array();
+    }
+
+    // merge the default parameters with the actual query
+    $field = array_merge($defaults, $field);
+
+    // dynamic page option
+    // ../
+    // ../../ etc.
+    $page    = $this->page($field['page']);
+    $items   = $page->{$field['name']}()->split($field['seperator']);
+    $options = array();
+
+    foreach($items as $item) {
+      $options[$item] = $item;
+    }
+
+    return $options;
+
   }
 
   public function optionsFromQuery($query) {


### PR DESCRIPTION
Adds the possibility to get fieldoptions from another field (e.g. a tag field) so that options can be defined dynamically.

```
favoritedrink:
    label: Your favorite drink
    type:  select
    options: field
    field:
      page:  ../
      name: availabledrinks
      seperator: ;
```

`page` enables to references a relative path to the page of the source field (parent page in the example). `name` is the name of the source field (`tags` by default). `seperator` lets you define the seperator the field value will be split by (default is `,`).