### PR TITLE
Fixes tags autocomplete for files, fix #699

### DIFF
--- a/app/fields/tags/tags.php
+++ b/app/fields/tags/tags.php
@@ -28,13 +28,15 @@ class TagsField extends TextField {
 
     } else if($page = $this->page()) {
 
-      empty($this->field) ? $field = $this->name() : $field = $this->field;
+      $field = empty($this->field) ? $this->name() : $this->field;
+      $model = is_a($this->model, 'File') ? 'file' : 'page';
 
       $query = array(
         'uri'       => $page->id(),
         'index'     => $this->index(),
         'field'     => $field,
         'yaml'      => $this->parentField,
+        'model'     => $model,
         'separator' => $this->separator(),
         '_csrf'     => panel()->csrf(),
       );

--- a/app/src/panel/autocomplete.php
+++ b/app/src/panel/autocomplete.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel;
 
 use A;
 use Exception;
+use Pages;
 
 class Autocomplete {
 
@@ -61,6 +62,7 @@ class Autocomplete {
       'uri'       => '/',
       'field'     => 'tags',
       'yaml'      => false,
+      'model'     => 'page',
       'separator' => true
     );
 
@@ -69,10 +71,15 @@ class Autocomplete {
     $pages   = $this->pages($page, $options['index'], $options);
     $yaml    = $options['yaml'];
 
-    if($yaml) {
+    if($yaml or $options['model'] == 'file') {
       $result = array();
       foreach($pages as $p) {
-        $values = $p->$yaml()->toStructure()->pluck($options['field'], $options['separator'], true);
+        if($yaml) {
+          $index = $p->$yaml()->toStructure();
+        } elseif($options['model'] == 'file') {
+          $index = $p->files();
+        }
+        $values = $index->pluck($options['field'], $options['separator'], true);
         $result = array_merge($result, $values);
       }
       $result = array_unique($result);
@@ -87,6 +94,9 @@ class Autocomplete {
   public function pages($page, $index, $params = array()) {
 
     switch($index) {
+      case 'self':
+        return new Pages(array($page));
+        break;
       case 'siblings':
       case 'children':
         return $page->$index();


### PR DESCRIPTION
Fixes/adds autocomplete for tags fields of files (by also passing the context - page/file - of the field to the autocomplete method).

It also introduces a new index option: `index: self` which only refers to the page of the field itself. This can be handy in several scenarios:
- Having two tags field on the same page, the second should be completed with values from the first but only from the same page (e.g. "categories" and "categories to highlight")
- Having a tags field in a structure field that should only be autocompleted with values from other structure entries of the same page.
- Having a file field that should be autocompleted with values from other files of only the same page.

To have tags field autocomplete working inside of a structure field this PR is crucial: #751