### PR TITLE
Fieldoptions: better relative paths resolving

### DIFF
--- a/app/src/panel/form/fieldoptions.php
+++ b/app/src/panel/form/fieldoptions.php
@@ -151,9 +151,12 @@ class FieldOptions {
           if($parent = $currentPage->parent()) {
             $currentPage = $parent;
           } else {
-            break;
+            $currentPage = site();
           }
           $path = str::substr($path, 3);
+        }
+        if(!empty($path)) {
+          $currentPage = $currentPage->find($path);
         }
         $page = $currentPage;
       } else {


### PR DESCRIPTION
Enables relative paths up to $site and back down again (e.g. `../../projects/project-a`).

Sure, you could just start from the toplevel with `projects/project-a`. But given the requests I have received just weekend in relation to the new "fieldoptions from tags field", quite a few people seem to prefer to do it this way. Certainly, not the most elegant way, but implementing this fix would provide consistency and ensure that it's still working no matter which way you try.