### PR TITLE
Fix default page parameter on site for fieldoptions

### DIFF
--- a/app/src/panel/form/fieldoptions.php
+++ b/app/src/panel/form/fieldoptions.php
@@ -66,7 +66,7 @@ class FieldOptions {
 
     // default field parameters
     $defaults = array(
-      'page'      => $this->field->page ? $this->field->page->id() : '',
+      'page'     => $this->field->page ? ($this->field->page->isSite() ? '/' : $this->field->page->id()) : '',
       'name'      => 'tags',
       'separator' => ',',
     );
@@ -98,7 +98,7 @@ class FieldOptions {
 
     // default query parameters
     $defaults = array(
-      'page'     => $this->field->page ? $this->field->page->id() : '',
+      'page'     => $this->field->page ? ($this->field->page->isSite() ? '/' : $this->field->page->id()) : '',
       'fetch'    => 'children',
       'value'    => '{{uid}}',
       'text'     => '{{title}}',


### PR DESCRIPTION
fix #768

**Old:**
```php
$this->field->page ?$this->field->page->id() : '',
```

**Problem:**
If `$this->field->page` is actually `$site` the `id()` method will only return an empty string instead of `'/'`. This is the easier more local fix, since I did not want to fiddle with `$site->id` in general.

**New:**
```php
$this->field->page ? ($this->field->page->isSite() ? '/' : $this->field->page->id()) : '',
```