### PR TITLE
Use $this->translation() getter

### DIFF
--- a/app/src/panel.php
+++ b/app/src/panel.php
@@ -350,7 +350,7 @@ class Panel {
   }
 
   public function direction() {
-    return $this->translation->direction();
+    return $this->translation()->direction();
   }
 
   public function launch($path = null) {


### PR DESCRIPTION
Fixes php error, thrown when using search panel (i think it happens when session expires)
```
Fatal error: Call to a member function direction() on null in .../panel/app/src/panel.php on line 353
```