### PR TITLE
Store: reset if meanwhile file got modified

### DIFF
--- a/app/src/panel/structure/store.php
+++ b/app/src/panel/structure/store.php
@@ -10,10 +10,11 @@ use Yaml;
 
 class Store {
 
-  public $id = null;
+  public $id          = null;
   public $structure;
-  public $source = array();
-  public $data = array();
+  public $source      = array();
+  public $data        = array();
+  public $age;
 
   public function __construct($structure, $source) {
     $this->structure = $structure;  
@@ -24,6 +25,14 @@ class Store {
   } 
 
   public function init() {
+
+    $age      = s::get($this->id() . '_age');
+    $modified = $this->structure->model()->modified();
+
+    if($age < $modified) {
+      $this->reset();
+      $age = $modified;
+    }
 
     $data = s::get($this->id());
 
@@ -43,7 +52,9 @@ class Store {
     }
 
     $this->data = $data;
+    $this->age  = $age ? $age : time();
     s::set($this->id, $this->data);
+    s::set($this->id . '_age', $this->age);
 
   }
 


### PR DESCRIPTION
This PR offers a first fix attempt around the whole issue of keeping the panel and file system in sync. This whole load of issues can occur when changes are made through the panel as well as through the file system, e.g. when editing with the panel and files directly via FTP; or when users can change files through front-end form input; or when plugin change/create files through hooks.

This PR tries to tackle the easier problem described in #687 first: On a panel page reload check if the file has been modified and get the values from the file if so, only if the session is still more current than the file, rely on the session store. Otherwise/so far, the panel blindly relies on the session store, which causes the problem that you need to logout to reset the session to actually see changes that are already in the file. Simple example: Blog comments stored in the form of structure field entries - new comments made through a front-end form will not appear in the panel without a sign-out/sign-in. Even worse, updating the page before signing-out/-in will just overwrite the outdated structure field content shown in the panel and present in the session store. So there is a high potential for loss of front-end input data even across multiple panel page reloads (which means we could be talking about a long time where is still valid store session will enforce its outdated data). This PR is an approach to fix this problem.

What it does not achieve yet, is to solve the problem of concurrent changes on the file system and the panel form (#688). Meaning: Concurrent changes that take place without any page (re-)load at the panel, where we could check for conflicts. This is much tougher to solve, not just technically but conceptually (warnings? conflict resolution? merging changes?). But it might also be less pressing as we are talking about a smaller timespan when concurrent changes would need to occur.

Would be curious to hear your thoughts, ideas - towards the general two issues but also towards this PR (suggestions for improvements, testing...), @bastianallgeier, @lukasbestle, @texnixe - but also just everyone who feels ready to dive a little deeper into the core of Kirby and the panel. 