### PR TITLE
Fix untranslatable fields, fix #781

### DIFF
--- a/app/controllers/pages.php
+++ b/app/controllers/pages.php
@@ -57,19 +57,19 @@ class PagesController extends Kirby\Panel\Controllers\Base {
         return $self->alert(l('pages.show.error.form'));
       }
 
-      // filter untranslatable fields
-      $serialized = $form->serialize();
+      $data = $form->serialize();
 
-      if(panel()->site()->language() != panel()->site()->defaultLanguage()) {
+      // filter untranslatable fields
+      if(!panel()->site()->isDefaultLang()) {
         foreach($form->fields() as $field) {
           if($field->translate() == false) {
-            $serialized[$field->name()] = null;
+            $data[$field->name()] = null;
           }
         }
       }
 
       try {
-        $page->update($serialized);
+        $page->update($data);
         $self->notify(':)');
         return $self->redirect($page);
       } catch(Exception $e) {

--- a/app/controllers/pages.php
+++ b/app/controllers/pages.php
@@ -57,8 +57,19 @@ class PagesController extends Kirby\Panel\Controllers\Base {
         return $self->alert(l('pages.show.error.form'));
       }
 
+      // filter untranslatable fields
+      $serialized = $form->serialize();
+
+      if(panel()->site()->language() != panel()->site()->defaultLanguage()) {
+        foreach($form->fields() as $field) {
+          if($field->translate() == false) {
+            $serialized[$field->name()] = null;
+          }
+        }
+      }
+
       try {
-        $page->update($form->serialize());
+        $page->update($serialized);
         $self->notify(':)');
         return $self->redirect($page);
       } catch(Exception $e) {

--- a/app/src/panel/form.php
+++ b/app/src/panel/form.php
@@ -93,6 +93,9 @@ class Form extends Brick {
 
     foreach($this->fields() as $field) {
 
+      // skip if not default language and untranslatable field
+      if(!panel()->site()->isDefaultLang() and $field->translate() === false) continue;
+
       $name  = $field->name();
       $value = $this->value($name);
 

--- a/app/src/panel/models/site.php
+++ b/app/src/panel/models/site.php
@@ -219,4 +219,8 @@ class Site extends \Site {
     return $this->multilang() ? $this->language()->code() : false;
   }
 
+  public function isDefaultLang() {
+    return $this->multilang() ? $this->language() == $this->defaultLanguage() : true;
+  }
+
 }


### PR DESCRIPTION
Fixes the `translate: false` option for fields. Values for these fields are not updated anymore for non-default languages. It will erase previous content of this field, but as in #781 discussed, I think this would be the best solution and also the most likely intended when setting `translate: false`.

Also fixes the validation of fields with `translate: false` (by skipping their validation since no value is saved anyways) - see #796.