### PR TITLE
Add missing sorting for pages created by subpage builder

### DIFF
--- a/app/src/panel/collections/children.php
+++ b/app/src/panel/collections/children.php
@@ -72,7 +72,8 @@ class Children extends \Children {
     foreach((array)$page->blueprint()->pages()->build() as $build) {
       $missing = a::missing($build, array('title', 'template', 'uid'));
       if(!empty($missing)) continue;
-      $page->children()->create($build['uid'], $build['template'], array('title' => $build['title']));
+      $subpage = $page->children()->create($build['uid'], $build['template'], array('title' => $build['title']));
+      if(isset($build['num'])) $subpage->sort($build['num']);
     }
 
     return $page;


### PR DESCRIPTION
The num is currently ignored but is described in the docs: https://getkirby.com/docs/panel/blueprints/subpages-settings