### PR TITLE
Fix issue with upload hook

### DIFF
--- a/app/src/panel/models/file.php
+++ b/app/src/panel/models/file.php
@@ -112,7 +112,7 @@ class File extends \File {
 
   }
 
-  public function update($data = array(), $sort = null) {  
+  public function update($data = array(), $sort = null, $trigger = true) {
 
     if($data == 'sort') {
       parent::update(array('sort' => $sort));
@@ -134,7 +134,9 @@ class File extends \File {
       parent::update($data);          
     }
 
-    kirby()->trigger('panel.file.update', $this);
+    if($trigger) {
+      kirby()->trigger('panel.file.update', $this);
+    }
 
   }
 
@@ -230,7 +232,7 @@ class File extends \File {
    
   }
 
-  public function createMeta() {
+  public function createMeta($triggerUpdateHook = true) {
 
     // save default meta 
     $meta = array();
@@ -239,7 +241,7 @@ class File extends \File {
       $meta[$field->name()] = $field->default();
     }
 
-    $this->update($meta);
+    $this->update($meta, null, $triggerUpdateHook);
 
     return $this;
 

--- a/app/src/panel/models/page/uploader.php
+++ b/app/src/panel/models/page/uploader.php
@@ -56,7 +56,8 @@ class Uploader {
     $file = $this->move($upload);
 
     // create the initial meta file
-    $file->createMeta();
+    // without triggering the update hook
+    $file->createMeta(false);
 
     // make sure that the file is being marked as updated
     touch($file->root());


### PR DESCRIPTION
When uploading a file, the `update` hook is called first making the `upload` hook useless in some scenarios.