### PR TITLE
avoid null value access because of uninitialized value

### DIFF
--- a/app/src/panel.php
+++ b/app/src/panel.php
@@ -359,7 +359,7 @@ class Panel {
   }
 
   public function direction() {
-    return $this->translation->direction();
+    return $this->translation()->direction();
   }
 
   public function launch($path = null) {


### PR DESCRIPTION
In the logs I saw a lot of entries like:
```
[31-May-2016 19:06:26 UTC] PHP Fatal error:  Uncaught Error: Call to a member function direction() on null in /var/www/kirby/panel/app/src/panel.php:362
Stack trace:
#0 /var/www/kirby/panel/app/src/panel.php(517): Kirby\Panel->direction()
#1 /var/www/kirby/panel/app/src/panel.php(227): Kirby\Panel->redirect('login')
#2 /var/www/kirby/panel/app/src/panel.php(161): Kirby\Panel->csrfCheck()
#3 /var/www/kirby/panel/index.php(48): Kirby\Panel->__construct(Object(Kirby), '/var/www/kirby...')
#4 {main}
  thrown in /var/www/kirby/panel/app/src/panel.php on line 362
```

Looks like `$this->translation` was not properly initialised.
Changing to function call from access var directly solved that.