### PR TITLE
Fix #447: Proper support for custom folder setup

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,8 +23,11 @@ if(file_exists($index . DS . 'site.php')) {
 }
 
 // fix the base url for the kirby installation
-if(!isset($kirby->urls->index)) {
-  $kirby->urls->index = dirname($kirby->url());
+// we always need to call the index() method because
+// it needs to detect the URL for the check below to work
+$indexUrl = $kirby->urls()->index();
+if($kirby->urls()->indexDetected === true) {
+  $kirby->urls->index = dirname($indexUrl);
 }
 
 // the default index directory


### PR DESCRIPTION
Previously the Panel would break if `kirby()->urls()->index()` was called (not set!) inside the `site.php` file for custom folder setups. The reason behind this is that the `index()` method caches its result and then the Panel's `index.php` would think that the URL has been set manually and not apply the URL fix.

This commit together with getkirby/kirby#477 fixes this behavior by checking instead if the URL has been detected or really set manually. This is a more reliable approach here.