### PR TITLE
Fix for issue #906

### DIFF
--- a/app/controllers/files.php
+++ b/app/controllers/files.php
@@ -169,14 +169,13 @@ class FilesController extends Kirby\Panel\Controllers\Base {
     $filenames = get('filenames');
     $counter   = 0;
 
-    foreach($filenames as $filename) {
-      if($file = $page->file($filename)) {
-        $counter++;
-        try {
-          $file->update('sort', $counter);
-        } catch(Exception $e) {
+    $files = $page->files()->find($filenames);
 
-        }
+    foreach ($files as $file) {
+      $counter++;
+      try {
+        $file->update('sort', $counter);
+      } catch(Exception $e) {
       }
     }
 


### PR DESCRIPTION
Fix for issue #906

After changing the for loop and the way the `$file` objects are created latency (TTFB) on localhost dropped from 13 seconds to 355ms (sorting 200+ images).