### PR TITLE
Append CSRF with $.ajaxPrefixer as string if source data are typeof s…

### DIFF
--- a/assets/js/src/app.js
+++ b/assets/js/src/app.js
@@ -26,10 +26,15 @@ var app = {
 
     // add the current csrf token to each post request
     $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
-      if(originalOptions.type && originalOptions.type.toLowerCase() == 'post') {      
-        options.data = $.param($.extend(originalOptions.data, {
-          csrf: $('body').attr('data-csrf')
-        }));
+      if(originalOptions.type && originalOptions.type.toLowerCase() == 'post') {
+        var csrf = $('body').attr('data-csrf');
+        if(typeof originalOptions.data == 'string' && originalOptions.data != '') {
+          options.data = originalOptions.data + '&csrf=' + csrf
+        } else {
+          options.data = $.param($.extend(originalOptions.data, {
+            csrf: csrf
+          }));
+        }
       }    
     });
 


### PR DESCRIPTION
Hi,
I've found that way how **csrf** is appended to every ajax POST didn't count with case that form data were passed as string (for example from `$('form').serialize()` function). In that case all source data were **removed and replaced** with csrf.

This can fix that.

Thanks,
Martin