### PR TITLE
fixed undefined variable store

### DIFF
--- a/app/src/panel/models/page/changes.php
+++ b/app/src/panel/models/page/changes.php
@@ -97,12 +97,10 @@ class Changes {
   }
 
   public function update($field, $data = null) {
-
+    $store = $this->data();
     if(is_null($data) and is_array($field)) {
-      $store = $this->data();
       $store[$this->id()] = $field;
     } else if(is_string($field)) {
-      $store = $this->data();
       if(!isset($store[$this->id()]) or !is_array($store[$this->id()])) {
         $store[$this->id()] = array();
       }


### PR DESCRIPTION
The variable store should be always defined as it is returnd at the end of the update method.

Currently (Kirby 2.4.1, Panel 2.4.1) we get a 500 error in the site options when we change a field and save it due to the undefined variable.

The returned error is `{"status":"error","code":8,"message":"Undefined variable: store"}`.
This workaround prevents this error message, the data is still saved.

See also the discard method which correctly defined the store variable at the beginning, independent of the logic below the definition.

This also affects the starterkit and the other distributions.