### PR TITLE
Hide subpages properly when option is set

### DIFF
--- a/app/src/panel/models/page/sidebar.php
+++ b/app/src/panel/models/page/sidebar.php
@@ -29,7 +29,7 @@ class Sidebar {
 
   public function subpages() {
 
-    if($this->page->ui()->pages() === false) {
+    if($this->blueprint->pages()->hide() === true) {
       return null;
     }
 


### PR DESCRIPTION
This fixes #978.

Setting the pages `hide` option to `true` on a parent page doesn't hide its subpages on the sidebar. 

```
pages:
  hide: true
```

This bug was introduced in v2.4.0.