### PR TITLE
Fix file sorting

### DIFF
--- a/app/src/panel/models/page.php
+++ b/app/src/panel/models/page.php
@@ -191,6 +191,10 @@ class Page extends \Page {
     return new Children($this);
   }
 
+  public function canSortFiles() {
+    return $this->blueprint()->files()->sortable();
+  }
+
   public function files() {
     return new Files($this);
   }


### PR DESCRIPTION
Editing blueprints to toggle file sorting currently has no effect in the panel, they are always sortable.

the function canSortFiles was removed in previous commit, which broke the ability to toggle file sorting from a blueprint