### PR TITLE
Fix broken image preview for documents

### DIFF
--- a/app/views/files/edit.php
+++ b/app/views/files/edit.php
@@ -21,7 +21,7 @@
     <a title="<?php _l('files.show.open') ?> (o)" data-shortcut="o" target="_blank" class="fileview-image-link fileview-preview-link" href="<?php __($file->url('preview')) ?>">
       <?php if($file->extension() == 'svg'): ?>
       <object data="<?php __($file->url('preview')) ?>"></object>
-      <?php elseif($file->options()->preview()): ?>
+      <?php elseif($file->options()->preview() && $file->type() === 'image'): ?>
       <img src="<?php __($file->url('preview')) ?>" alt="<?php __($file->filename()) ?>">
       <?php else: ?>
       <span>

--- a/app/views/files/index.php
+++ b/app/views/files/index.php
@@ -34,7 +34,7 @@
           <a class="file-preview file-preview-is-<?php __($file->type()) ?>" href="<?php __($file->url('edit')) ?>">
             <?php if($file->extension() == 'svg'): ?>
             <object data="<?php __($file->url('preview')) ?>"></object>
-            <?php elseif($file->options()->preview()): ?>
+            <?php elseif($file->options()->preview() && $file->type() === 'image'): ?>
             <img src="<?php __($file->crop(400, 266)->url()) ?>" alt="<?php __($file->filename()) ?>">
             <?php else: ?>
             <span><?php __($file->extension()) ?></span>


### PR DESCRIPTION
Currently the preview for documents shows a broken image icon. This fixes this by checking if a file is of the type image.