### PR TITLE
Stopped wiping of thumbnails after new upload

### DIFF
--- a/app/src/panel/models/page/uploader.php
+++ b/app/src/panel/models/page/uploader.php
@@ -64,9 +64,6 @@ class Uploader {
     // make sure that the file is being marked as updated
     touch($file->root());
 
-    // clean the thumbs folder
-    $this->page->removeThumbs();
-
     kirby()->trigger($event, $file);          
 
   }


### PR DESCRIPTION
I'm not sure what the idea behind wiping all the thumbnails after any
file upload is; whether there's a bigger sense that I'm not able to
grasp here. So, to be taken with caution.

This is a potential fix for getkirby/kirby#460.