### PR TITLE
Added space between error message and value

### DIFF
--- a/app/src/panel/models/page/uploader.php
+++ b/app/src/panel/models/page/uploader.php
@@ -171,12 +171,12 @@ class Uploader {
 
     // Files blueprint option 'type'
     if(count($filesettings->type()) > 0 and !in_array($file->type(), $filesettings->type())) {
-      throw new Exception(l('files.add.blueprint.type.error') . implode(', ', $filesettings->type()));
+      throw new Exception(l('files.add.blueprint.type.error') . ' ' . implode(', ', $filesettings->type()));
     }
 
     // Files blueprint option 'size'
     if($filesettings->size() and f::size($file->root()) > $filesettings->size()) {
-      throw new Exception(l('files.add.blueprint.size.error') . f::niceSize($filesettings->size()));
+      throw new Exception(l('files.add.blueprint.size.error') . ' ' . f::niceSize($filesettings->size()));
     }
 
     // Files blueprint option 'width'


### PR DESCRIPTION
When uploading a file of the wrong file type or a file size too large, an error message is shown. This error message is missing a space between the message and value. This PR adds this missing space.