### PR TITLE
More stable language switching (Fix #943, Fix #1106)

### DIFF
--- a/app/snippets/languages.php
+++ b/app/snippets/languages.php
@@ -10,7 +10,7 @@
     <ul class="nav nav-list dropdown-list">
       <?php foreach($languages as $lang): ?>
       <li>
-        <a href="?language=<?php echo $lang->code() ?>"><?php __(strtoupper($lang->code())) ?></a>
+        <a href="?_language=<?php echo $lang->code() ?>"><?php __(strtoupper($lang->code())) ?></a>
       </li>
       <?php endforeach ?>
     </ul>

--- a/app/src/panel.php
+++ b/app/src/panel.php
@@ -269,7 +269,7 @@ class Panel {
 
     if(!$this->site->multilang()) {
       $language = null;
-    } else if($language = get('language') or $language = s::get('kirby_panel_lang')) {
+    } else if($language = get('_language') or $language = s::get('kirby_panel_lang')) {
       // $language is already set
     } else {
       $language = null;

--- a/app/src/panel/form.php
+++ b/app/src/panel/form.php
@@ -328,6 +328,15 @@ class Form extends Brick {
     $redirectField->value = $this->redirect();
     $fieldset->append($redirectField);
 
+    // pass the language code
+    if (panel()->site()->multilang() === true) {
+      $langField = new Brick('input');
+      $langField->type  = 'hidden';
+      $langField->name  = '_language';
+      $langField->value = panel()->site()->language()->code();
+      $fieldset->append($langField);
+    }
+
     $this->append($fieldset);
 
     $buttons = new Brick('fieldset');


### PR DESCRIPTION
Moving the language switching query variable to a private `_language` var should avoid future problems with additional `language` fields in forms. The additional hidden field to send the current language when submitting a form should also avoid accidental language switching and thus overwriting of wrong content. 