### PR TITLE
Hide files properly when "hide" option is set

### DIFF
--- a/app/src/panel/models/page/sidebar.php
+++ b/app/src/panel/models/page/sidebar.php
@@ -56,7 +56,7 @@ class Sidebar {
 
   public function files() {
 
-    if($this->page->ui()->files() === false) {
+    if($this->blueprint->files()->hide() === true) {
       return null;
     }
 


### PR DESCRIPTION
Setting the files `hide` option to `true` on a parent page doesn't hide its files in the sidebar.

```yml
files:
  hide: true
```

This bug was introduced in v2.4.0.

Refs #982 